### PR TITLE
CLDCONNECT-1372 Bugs and test cases fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+2.0.0
+=====
+ - Upgraded google api services calendar to v3-rev77-1.17.0-rc.
+ - Upgraded Devkit to 3.5.0-SNAPSHOT.
+ - Fixed Class Versioning Issue.
+ - Fixed Quick add events operation hung issue.
+ - Removed @Optional as it is redundant when used along @Default.
+ - Removed deprecated @OAuthInvalidateAccessTokenOn and added @ReconnectOn on the Connector.
+ - Fixed test cases
+    - If a test is not functionally designed to test calendar creation or deletion, it just uses the default/primary calendar.
+    - If a test is working on an event, it uses different test data to any other test that uses an event.
+    - Added sleep time (10 sec) between each operation to slow down the hits to the google api.
+
+ - Known Issues
+    - Avoid executing Regression/Smoke test suites multiple times in a single day in order to avoid "Calendar usage limits exceeded." error.

--- a/pom.xml
+++ b/pom.xml
@@ -61,41 +61,4 @@
 		<developerConnection>scm:git:git@github.com:mulesoft/google-calendar-connector.git</developerConnection>
 		<url>https://github.com/mulesoft/google-calendar-connector</url>
 	</scm>
-
-	  <profiles>
-        <profile>
-            <id>windows_profile</id>
-            <activation>
-                <os>
-                    <family>Windows</family>
-                </os>
-            </activation>
-            <properties>
-                <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-            </properties>
-        </profile>
-        <profile>
-            <id>linux_profile</id>
-            <activation>
-                <os>
-                    <name>linux</name>
-                </os>
-            </activation>
-            <properties>
-                <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-            </properties>
-        </profile>
-        <profile>
-            <id>osx_profile</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                </os>
-            </activation>
-            <properties>
-                <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
-            </properties>
-        </profile>
-    </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
 		<groupId>org.mule.tools.devkit</groupId>
 		<artifactId>mule-devkit-parent</artifactId>
-		<version>3.5.0-M4</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
 		<dependency>
 			<groupId>com.google.apis</groupId>
 			<artifactId>google-api-services-calendar</artifactId>
-			<version>v3-rev9-1.7.2-beta</version>
+			<version>v3-rev77-1.17.0-rc</version>
 		</dependency>
-	</dependencies>
+    </dependencies>
 
 	<repositories>
 		<repository>

--- a/src/main/java/org/mule/module/google/calendar/GoogleCalendarConnector.java
+++ b/src/main/java/org/mule/module/google/calendar/GoogleCalendarConnector.java
@@ -67,7 +67,7 @@ import com.google.api.services.calendar.model.FreeBusyRequestItem;
  * Google Calendars Cloud connector.
  * This connector covers almost all the Google Calendar API v3 using OAuth2 for authentication.
  *
- * @author mariano.gonzalez@mulesoft.com
+ * @author MuleSoft, Inc.
  */
 @Connector(name="google-calendars", schemaVersion="1.0", friendlyName="Google Calendars", minMuleVersion="3.5", configElementName="config-with-oauth")
 @OAuth2(
@@ -103,7 +103,6 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
      * Application name registered on Google API console
      */
     @Configurable
-    @Optional
     @Default("Mule-GoogleCalendarConnector/1.0")
     private String applicationName;
     
@@ -112,7 +111,6 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
      */
     @OAuthScope
     @Configurable
-    @Optional
     @Default(USER_PROFILE_SCOPE + " " + CalendarScopes.CALENDAR)
     private String scope;
     
@@ -166,7 +164,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public Calendar createCalendar(@Optional @Default("#[payload]") Calendar calendar) throws IOException {
+    public Calendar createCalendar(@Default("#[payload]") Calendar calendar) throws IOException {
   	   return new Calendar(this.client.calendars().insert(calendar.wrapped()).execute());
     }
     
@@ -188,7 +186,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
     @Paged
     public PagingDelegate<CalendarList> getCalendarList(
-    		final @Optional @Default("false") boolean showHidden,
+    		final @Default("false") boolean showHidden,
     		final PagingConfiguration pagingConfiguration) throws IOException {
     	
     	return new TokenBasedPagingDelegate<CalendarList>() {
@@ -252,7 +250,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public CalendarList updateCalendarList(String id, @Optional @Default("#[payload]") CalendarList calendarList) throws IOException {
+    public CalendarList updateCalendarList(String id, @Default("#[payload]") CalendarList calendarList) throws IOException {
     	return new CalendarList(this.client.calendarList().update(id, calendarList.wrapped()).execute());
     }
     
@@ -286,7 +284,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public Calendar updateCalendar(String id, @Optional @Default("#[payload]") Calendar calendar) throws IOException {
+    public Calendar updateCalendar(String id, @Default("#[payload]") Calendar calendar) throws IOException {
     	return new Calendar(this.client.calendars().update(id, calendar.wrapped()).execute());
     }
     
@@ -356,13 +354,13 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     		final @Optional Integer maxAttendees,
     		final @Optional String orderBy,
     		final @Optional String query,
-    		final @Optional @Default("false") boolean showDeleted,
-    		final @Optional @Default("false") boolean showHiddenInvitations,
-    		final @Optional @Default("true") boolean singleEvents,
+    		final @Default("false") boolean showDeleted,
+    		final @Default("false") boolean showHiddenInvitations,
+    		final @Default("true") boolean singleEvents,
     		final @Optional String timeMin,
     		final @Optional String timeMax,
-    		final @Optional @Default(DateTimeConstants.RFC3339) String datetimeFormat,
-    		final @Optional @Default("UTC") String timezone,
+    		final @Default(DateTimeConstants.RFC3339) String datetimeFormat,
+    		final @Default("UTC") String timezone,
     		final @Optional String lastUpdated,
     		final PagingConfiguration pagingConfiguration) throws IOException {
     	
@@ -407,7 +405,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public Event importEvent(String calendarId, @Optional @Default("#[payload]") Event calendarEvent) throws IOException {
+    public Event importEvent(String calendarId, @Default("#[payload]") Event calendarEvent) throws IOException {
     	return new Event(this.client.events().calendarImport(calendarId, calendarEvent.wrapped()).execute());
     }
     
@@ -457,7 +455,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public Event insertEvent(String calendarId, @Optional @Default("#[payload]") Event calendarEvent) throws IOException {
+    public Event insertEvent(String calendarId, @Default("#[payload]") Event calendarEvent) throws IOException {
     	return new Event(this.client.events().insert(calendarId, calendarEvent.wrapped()).execute());
     }
     
@@ -477,7 +475,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
     public BatchResponse<Event> batchInsertEvent(
     			String calendarId,
-    			@Optional @Default("#[payload]") Collection<Event> calendarEvents) throws IOException {
+    		    @Default("#[payload]") Collection<Event> calendarEvents) throws IOException {
     	
     	EventBatchCallback callback = new EventBatchCallback();
     	com.google.api.services.calendar.Calendar client = this.client; 
@@ -507,7 +505,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public BatchResponse<Event> batchUpdateEvent(String calendarId, @Optional @Default("#[payload]") Collection<Event> calendarEvents) throws IOException {
+    public BatchResponse<Event> batchUpdateEvent(String calendarId, @Default("#[payload]") Collection<Event> calendarEvents) throws IOException {
     	
     	EventBatchCallback callback = new EventBatchCallback();
     	com.google.api.services.calendar.Calendar client = this.client; 
@@ -536,7 +534,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public void batchDeleteEvent(String calendarId, @Optional @Default("#[payload]") Collection<Event> calendarEvents) throws IOException {
+    public void batchDeleteEvent(String calendarId, @Default("#[payload]") Collection<Event> calendarEvents) throws IOException {
     	
     	VoidBatchCallback callback = new VoidBatchCallback();
     	com.google.api.services.calendar.Calendar client = this.client; 
@@ -563,7 +561,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public BatchResponse<Calendar> batchInsertCalendar(@Optional @Default("#[payload]") Collection<Calendar> calendars) throws IOException {
+    public BatchResponse<Calendar> batchInsertCalendar(@Default("#[payload]") Collection<Calendar> calendars) throws IOException {
     	
     	CalendarBatchCallback callback = new CalendarBatchCallback();
     	com.google.api.services.calendar.Calendar client = this.client; 
@@ -592,7 +590,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public BatchResponse<Calendar> batchUpdateCalendar(@Optional @Default("#[payload]") Collection<Calendar> calendars) throws IOException {
+    public BatchResponse<Calendar> batchUpdateCalendar(@Default("#[payload]") Collection<Calendar> calendars) throws IOException {
     	
     	CalendarBatchCallback callback = new CalendarBatchCallback();
     	com.google.api.services.calendar.Calendar client = this.client; 
@@ -620,7 +618,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public void batchDeleteCalendar(@Optional @Default("#[payload]") Collection<Calendar> calendars) throws IOException {
+    public void batchDeleteCalendar(@Default("#[payload]") Collection<Calendar> calendars) throws IOException {
     	
     	VoidBatchCallback callback = new VoidBatchCallback();
     	com.google.api.services.calendar.Calendar client = this.client; 
@@ -661,8 +659,8 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     				final String calendarId,
     				final String eventId,
     				final @Optional Integer maxAttendess,
-    				final @Optional @Default("false") boolean showDeleted,
-    				final @Optional @Default("UTC") String timezone,
+    				final @Default("false") boolean showDeleted,
+    				final @Default("UTC") String timezone,
     				final @Optional String originalStart,
     				final PagingConfiguration pagingConfiguration) throws IOException {
     	
@@ -733,7 +731,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public Event updateEvent(String calendarId, String eventId, @Optional @Default("#[payload]") Event calendarEvent) throws IOException {
+    public Event updateEvent(String calendarId, String eventId, @Default("#[payload]") Event calendarEvent) throws IOException {
     	return new Event(this.client.events().update(calendarId, eventId, calendarEvent.wrapped()).execute());
     }
     
@@ -757,9 +755,9 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     public FreeBusy getFreeTime(
     		String timeMin,
 			String timeMax,
-			@Optional @Default("#[payload]") List<String> ids,
-			@Optional @Default("UTC") String timezone,
-			@Optional @Default(DateTimeConstants.RFC3339) String datetimeFormat,
+			@Default("#[payload]") List<String> ids,
+			@Default("UTC") String timezone,
+			@Default(DateTimeConstants.RFC3339) String datetimeFormat,
 			@Optional Integer maxCalendarExpansion) throws IOException {
     	
     	FreeBusyRequest query = new FreeBusyRequest();
@@ -886,7 +884,7 @@ public class GoogleCalendarConnector extends AbstractGoogleOAuthConnector {
     @Processor
     @OAuthProtected
 	@OAuthInvalidateAccessTokenOn(exception=OAuthTokenExpiredException.class)
-    public AclRule updateAclRule(String calendarId,String ruleId, @Optional @Default("#[payload]") AclRule aclRule) throws IOException {
+    public AclRule updateAclRule(String calendarId,String ruleId, @Default("#[payload]") AclRule aclRule) throws IOException {
     	return new AclRule(this.client.acl().update(calendarId, ruleId, aclRule.wrapped()).execute());
     }
     

--- a/src/main/java/org/mule/module/google/calendar/GoogleCalendarConnector.java
+++ b/src/main/java/org/mule/module/google/calendar/GoogleCalendarConnector.java
@@ -52,7 +52,7 @@ import java.util.List;
  *
  * @author MuleSoft, Inc.
  */
-@Connector(name="google-calendars", schemaVersion="2.0", friendlyName="Google Calendars", minMuleVersion="3.5", configElementName="config-with-oauth")
+@Connector(name="google-calendars", schemaVersion="1.0", friendlyName="Google Calendars", minMuleVersion="3.5", configElementName="config-with-oauth")
 @OAuth2(
 		authorizationUrl = "https://accounts.google.com/o/oauth2/auth",
 		accessTokenUrl = "https://accounts.google.com/o/oauth2/token",

--- a/src/main/java/org/mule/module/google/calendar/model/AclRule.java
+++ b/src/main/java/org/mule/module/google/calendar/model/AclRule.java
@@ -12,6 +12,8 @@ package org.mule.module.google.calendar.model;
 
 import org.mule.modules.google.api.model.BaseWrapper;
 
+import java.io.IOException;
+
 /**
  * Wrapper for {@link com.google.api.services.calendar.model.AclRule}
  * to make it data mapper friendly.
@@ -64,8 +66,23 @@ public class AclRule extends BaseWrapper<com.google.api.services.calendar.model.
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 
+    public String getEtag() {
+        return wrapped.getEtag();
+    }
+
+    public String getKind() {
+        return wrapped.getKind();
+    }
+
+    public com.google.api.services.calendar.model.AclRule setEtag(String etag) {
+        return wrapped.setEtag(etag);
+    }
+
+    public com.google.api.services.calendar.model.AclRule setKind(String kind) {
+        return wrapped.setKind(kind);
+    }
 }

--- a/src/main/java/org/mule/module/google/calendar/model/Calendar.java
+++ b/src/main/java/org/mule/module/google/calendar/model/Calendar.java
@@ -10,11 +10,11 @@
 
 package org.mule.module.google.calendar.model;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.mule.modules.google.api.model.BaseWrapper;
 
-import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.util.ClassInfo;
 
 /**
@@ -69,10 +69,6 @@ public class Calendar extends BaseWrapper<com.google.api.services.calendar.model
 		return wrapped.getUnknownKeys();
 	}
 
-	public HttpHeaders getResponseHeaders() {
-		return wrapped.getResponseHeaders();
-	}
-
 	public final ClassInfo getClassInfo() {
 		return wrapped.getClassInfo();
 	}
@@ -109,10 +105,6 @@ public class Calendar extends BaseWrapper<com.google.api.services.calendar.model
 		wrapped.setId(id);
 	}
 
-	public void setResponseHeaders(HttpHeaders responseHeaders) {
-		wrapped.setResponseHeaders(responseHeaders);
-	}
-
 	public final void setUnknownKeys(Map<String, Object> unknownFields) {
 		wrapped.setUnknownKeys(unknownFields);
 	}
@@ -121,7 +113,9 @@ public class Calendar extends BaseWrapper<com.google.api.services.calendar.model
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
+
+
 }

--- a/src/main/java/org/mule/module/google/calendar/model/CalendarList.java
+++ b/src/main/java/org/mule/module/google/calendar/model/CalendarList.java
@@ -10,6 +10,7 @@
 
 package org.mule.module.google.calendar.model;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.mule.modules.google.api.model.BaseWrapper;
@@ -84,10 +85,6 @@ public class CalendarList extends BaseWrapper<CalendarListEntry> {
 		return wrapped.hashCode();
 	}
 
-	public void setDefaultReminders(List<EventReminder> defaultReminders) {
-		wrapped.setDefaultReminders(EventReminder.unwrapp(defaultReminders, com.google.api.services.calendar.model.EventReminder.class));
-	}
-
 	public void setDescription(String description) {
 		wrapped.setDescription(description);
 	}
@@ -132,7 +129,59 @@ public class CalendarList extends BaseWrapper<CalendarListEntry> {
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
+
+    public CalendarListEntry setNotificationSettings(CalendarListEntry.NotificationSettings notificationSettings) {
+        return wrapped.setNotificationSettings(notificationSettings);
+    }
+
+    public CalendarListEntry.NotificationSettings getNotificationSettings() {
+        return wrapped.getNotificationSettings();
+    }
+
+    public String getKind() {
+        return wrapped.getKind();
+    }
+
+    public String getEtag() {
+        return wrapped.getEtag();
+    }
+
+    public CalendarListEntry setEtag(String etag) {
+        return wrapped.setEtag(etag);
+    }
+
+    public String getForegroundColor() {
+        return wrapped.getForegroundColor();
+    }
+
+    public String getBackgroundColor() {
+        return wrapped.getBackgroundColor();
+    }
+
+    public Boolean getPrimary() {
+        return wrapped.getPrimary();
+    }
+
+    public CalendarListEntry setKind(String kind) {
+        return wrapped.setKind(kind);
+    }
+
+    public CalendarListEntry setDefaultReminders(List<com.google.api.services.calendar.model.EventReminder> defaultReminders) {
+        return wrapped.setDefaultReminders(defaultReminders);
+    }
+
+    public CalendarListEntry setForegroundColor(String foregroundColor) {
+        return wrapped.setForegroundColor(foregroundColor);
+    }
+
+    public CalendarListEntry setPrimary(Boolean primary) {
+        return wrapped.setPrimary(primary);
+    }
+
+    public CalendarListEntry setBackgroundColor(String backgroundColor) {
+        return wrapped.setBackgroundColor(backgroundColor);
+    }
 }

--- a/src/main/java/org/mule/module/google/calendar/model/CalendarList.java
+++ b/src/main/java/org/mule/module/google/calendar/model/CalendarList.java
@@ -85,6 +85,10 @@ public class CalendarList extends BaseWrapper<CalendarListEntry> {
 		return wrapped.hashCode();
 	}
 
+	public void setDefaultReminders(List<EventReminder> defaultReminders) {
+		wrapped.setDefaultReminders(EventReminder.unwrapp(defaultReminders, com.google.api.services.calendar.model.EventReminder.class));
+	}
+
 	public void setDescription(String description) {
 		wrapped.setDescription(description);
 	}
@@ -131,57 +135,13 @@ public class CalendarList extends BaseWrapper<CalendarListEntry> {
 
 	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
-	}
-
-    public CalendarListEntry setNotificationSettings(CalendarListEntry.NotificationSettings notificationSettings) {
-        return wrapped.setNotificationSettings(notificationSettings);
     }
 
-    public CalendarListEntry.NotificationSettings getNotificationSettings() {
-        return wrapped.getNotificationSettings();
-    }
-
-    public String getKind() {
-        return wrapped.getKind();
-    }
-
-    public String getEtag() {
-        return wrapped.getEtag();
-    }
-
-    public CalendarListEntry setEtag(String etag) {
-        return wrapped.setEtag(etag);
-    }
-
-    public String getForegroundColor() {
-        return wrapped.getForegroundColor();
-    }
-
-    public String getBackgroundColor() {
-        return wrapped.getBackgroundColor();
-    }
-
-    public Boolean getPrimary() {
-        return wrapped.getPrimary();
-    }
-
-    public CalendarListEntry setKind(String kind) {
-        return wrapped.setKind(kind);
-    }
-
-    public CalendarListEntry setDefaultReminders(List<com.google.api.services.calendar.model.EventReminder> defaultReminders) {
-        return wrapped.setDefaultReminders(defaultReminders);
-    }
-
-    public CalendarListEntry setForegroundColor(String foregroundColor) {
-        return wrapped.setForegroundColor(foregroundColor);
+    public boolean isPrimary() {
+        return wrapped.isPrimary();
     }
 
     public CalendarListEntry setPrimary(Boolean primary) {
         return wrapped.setPrimary(primary);
-    }
-
-    public CalendarListEntry setBackgroundColor(String backgroundColor) {
-        return wrapped.setBackgroundColor(backgroundColor);
     }
 }

--- a/src/main/java/org/mule/module/google/calendar/model/Creator.java
+++ b/src/main/java/org/mule/module/google/calendar/model/Creator.java
@@ -10,7 +10,10 @@
 
 package org.mule.module.google.calendar.model;
 
+import com.google.api.services.calendar.model.Event;
 import org.mule.modules.google.api.model.BaseWrapper;
+
+import java.io.IOException;
 
 
 /**
@@ -19,13 +22,13 @@ import org.mule.modules.google.api.model.BaseWrapper;
  * 
  * @author mariano.gonzalez@mulesoft.com
  */
-public class Creator extends BaseWrapper<com.google.api.services.calendar.model.Event.Creator>{
+public class Creator extends BaseWrapper<Event.Creator>{
 
 	public Creator(){
-		this(new com.google.api.services.calendar.model.Event.Creator());
+		this(new Event.Creator());
 	}
 	
-	public Creator(com.google.api.services.calendar.model.Event.Creator wrapped) {
+	public Creator(Event.Creator wrapped) {
 		super(wrapped);
 	}
 
@@ -65,7 +68,15 @@ public class Creator extends BaseWrapper<com.google.api.services.calendar.model.
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
+
+    public Event.Creator setId(String id) {
+        return wrapped.setId(id);
+    }
+
+    public String getId() {
+        return wrapped.getId();
+    }
 }

--- a/src/main/java/org/mule/module/google/calendar/model/Event.java
+++ b/src/main/java/org/mule/module/google/calendar/model/Event.java
@@ -171,6 +171,10 @@ public class Event extends BaseWrapper<com.google.api.services.calendar.model.Ev
 		wrapped.setId(id);
 	}
 
+	public void setAttendees(List<org.mule.module.google.calendar.model.EventAttendee> attendees) {
+		wrapped.setAttendees(org.mule.module.google.calendar.model.EventAttendee.unwrapp(attendees, EventAttendee.class));
+	}
+
 	public void setHtmlLink(String htmlLink) {
 		wrapped.setHtmlLink(htmlLink);
 	}
@@ -285,101 +289,5 @@ public class Event extends BaseWrapper<com.google.api.services.calendar.model.Ev
 
 	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
-	}
-
-    public com.google.api.services.calendar.model.Event setStart(com.google.api.services.calendar.model.EventDateTime start) {
-        return wrapped.setStart(start);
-    }
-
-    public com.google.api.services.calendar.model.Event setEnd(com.google.api.services.calendar.model.EventDateTime end) {
-        return wrapped.setEnd(end);
-    }
-
-    public com.google.api.services.calendar.model.Event.Source getSource() {
-        return wrapped.getSource();
-    }
-
-    public com.google.api.services.calendar.model.Event setExtendedProperties(com.google.api.services.calendar.model.Event.ExtendedProperties extendedProperties) {
-        return wrapped.setExtendedProperties(extendedProperties);
-    }
-
-    public com.google.api.services.calendar.model.Event setOrganizer(com.google.api.services.calendar.model.Event.Organizer organizer) {
-        return wrapped.setOrganizer(organizer);
-    }
-
-    public com.google.api.services.calendar.model.Event setSource(com.google.api.services.calendar.model.Event.Source source) {
-        return wrapped.setSource(source);
-    }
-
-    public com.google.api.services.calendar.model.Event set(String fieldName, Object value) {
-        return wrapped.set(fieldName, value);
-    }
-
-    public com.google.api.services.calendar.model.Event setUpdated(com.google.api.client.util.DateTime updated) {
-        return wrapped.setUpdated(updated);
-    }
-
-    public com.google.api.services.calendar.model.Event.Gadget getGadget() {
-        return wrapped.getGadget();
-    }
-
-    public com.google.api.services.calendar.model.Event setGadget(com.google.api.services.calendar.model.Event.Gadget gadget) {
-        return wrapped.setGadget(gadget);
-    }
-
-    public com.google.api.services.calendar.model.Event setLocked(Boolean locked) {
-        return wrapped.setLocked(locked);
-    }
-
-    public com.google.api.services.calendar.model.Event setCreator(com.google.api.services.calendar.model.Event.Creator creator) {
-        return wrapped.setCreator(creator);
-    }
-
-    public com.google.api.services.calendar.model.Event setAttendees(List<EventAttendee> attendees) {
-        return wrapped.setAttendees(attendees);
-    }
-
-    public com.google.api.services.calendar.model.Event setReminders(com.google.api.services.calendar.model.Event.Reminders reminders) {
-        return wrapped.setReminders(reminders);
-    }
-
-    public com.google.api.services.calendar.model.Event setEndTimeUnspecified(Boolean endTimeUnspecified) {
-        return wrapped.setEndTimeUnspecified(endTimeUnspecified);
-    }
-
-    public com.google.api.services.calendar.model.Event setHangoutLink(String hangoutLink) {
-        return wrapped.setHangoutLink(hangoutLink);
-    }
-
-    public com.google.api.services.calendar.model.Event setCreated(com.google.api.client.util.DateTime created) {
-        return wrapped.setCreated(created);
-    }
-
-    public Boolean getLocked() {
-        return wrapped.getLocked();
-    }
-
-    public Boolean getEndTimeUnspecified() {
-        return wrapped.getEndTimeUnspecified();
-    }
-
-    public String getKind() {
-        return wrapped.getKind();
-    }
-
-    public com.google.api.services.calendar.model.Event setOriginalStartTime(com.google.api.services.calendar.model.EventDateTime originalStartTime) {
-        return wrapped.setOriginalStartTime(originalStartTime);
-    }
-
-    public com.google.api.services.calendar.model.Event setKind(String kind) {
-        return wrapped.setKind(kind);
-    }
-
-    public String getEtag() {
-        return wrapped.getEtag();
-    }
-
-    public String getHangoutLink() {
-        return wrapped.getHangoutLink();
     }
 }

--- a/src/main/java/org/mule/module/google/calendar/model/Event.java
+++ b/src/main/java/org/mule/module/google/calendar/model/Event.java
@@ -10,6 +10,7 @@
 
 package org.mule.module.google.calendar.model;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.mule.modules.google.api.datetime.DateTime;
@@ -170,10 +171,6 @@ public class Event extends BaseWrapper<com.google.api.services.calendar.model.Ev
 		wrapped.setId(id);
 	}
 
-	public void setAttendees(List<org.mule.module.google.calendar.model.EventAttendee> attendees) {
-		wrapped.setAttendees(org.mule.module.google.calendar.model.EventAttendee.unwrapp(attendees, EventAttendee.class));
-	}
-
 	public void setHtmlLink(String htmlLink) {
 		wrapped.setHtmlLink(htmlLink);
 	}
@@ -286,7 +283,103 @@ public class Event extends BaseWrapper<com.google.api.services.calendar.model.Ev
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
+
+    public com.google.api.services.calendar.model.Event setStart(com.google.api.services.calendar.model.EventDateTime start) {
+        return wrapped.setStart(start);
+    }
+
+    public com.google.api.services.calendar.model.Event setEnd(com.google.api.services.calendar.model.EventDateTime end) {
+        return wrapped.setEnd(end);
+    }
+
+    public com.google.api.services.calendar.model.Event.Source getSource() {
+        return wrapped.getSource();
+    }
+
+    public com.google.api.services.calendar.model.Event setExtendedProperties(com.google.api.services.calendar.model.Event.ExtendedProperties extendedProperties) {
+        return wrapped.setExtendedProperties(extendedProperties);
+    }
+
+    public com.google.api.services.calendar.model.Event setOrganizer(com.google.api.services.calendar.model.Event.Organizer organizer) {
+        return wrapped.setOrganizer(organizer);
+    }
+
+    public com.google.api.services.calendar.model.Event setSource(com.google.api.services.calendar.model.Event.Source source) {
+        return wrapped.setSource(source);
+    }
+
+    public com.google.api.services.calendar.model.Event set(String fieldName, Object value) {
+        return wrapped.set(fieldName, value);
+    }
+
+    public com.google.api.services.calendar.model.Event setUpdated(com.google.api.client.util.DateTime updated) {
+        return wrapped.setUpdated(updated);
+    }
+
+    public com.google.api.services.calendar.model.Event.Gadget getGadget() {
+        return wrapped.getGadget();
+    }
+
+    public com.google.api.services.calendar.model.Event setGadget(com.google.api.services.calendar.model.Event.Gadget gadget) {
+        return wrapped.setGadget(gadget);
+    }
+
+    public com.google.api.services.calendar.model.Event setLocked(Boolean locked) {
+        return wrapped.setLocked(locked);
+    }
+
+    public com.google.api.services.calendar.model.Event setCreator(com.google.api.services.calendar.model.Event.Creator creator) {
+        return wrapped.setCreator(creator);
+    }
+
+    public com.google.api.services.calendar.model.Event setAttendees(List<EventAttendee> attendees) {
+        return wrapped.setAttendees(attendees);
+    }
+
+    public com.google.api.services.calendar.model.Event setReminders(com.google.api.services.calendar.model.Event.Reminders reminders) {
+        return wrapped.setReminders(reminders);
+    }
+
+    public com.google.api.services.calendar.model.Event setEndTimeUnspecified(Boolean endTimeUnspecified) {
+        return wrapped.setEndTimeUnspecified(endTimeUnspecified);
+    }
+
+    public com.google.api.services.calendar.model.Event setHangoutLink(String hangoutLink) {
+        return wrapped.setHangoutLink(hangoutLink);
+    }
+
+    public com.google.api.services.calendar.model.Event setCreated(com.google.api.client.util.DateTime created) {
+        return wrapped.setCreated(created);
+    }
+
+    public Boolean getLocked() {
+        return wrapped.getLocked();
+    }
+
+    public Boolean getEndTimeUnspecified() {
+        return wrapped.getEndTimeUnspecified();
+    }
+
+    public String getKind() {
+        return wrapped.getKind();
+    }
+
+    public com.google.api.services.calendar.model.Event setOriginalStartTime(com.google.api.services.calendar.model.EventDateTime originalStartTime) {
+        return wrapped.setOriginalStartTime(originalStartTime);
+    }
+
+    public com.google.api.services.calendar.model.Event setKind(String kind) {
+        return wrapped.setKind(kind);
+    }
+
+    public String getEtag() {
+        return wrapped.getEtag();
+    }
+
+    public String getHangoutLink() {
+        return wrapped.getHangoutLink();
+    }
 }

--- a/src/main/java/org/mule/module/google/calendar/model/EventAttendee.java
+++ b/src/main/java/org/mule/module/google/calendar/model/EventAttendee.java
@@ -12,6 +12,8 @@ package org.mule.module.google.calendar.model;
 
 import org.mule.modules.google.api.model.BaseWrapper;
 
+import java.io.IOException;
+
 /**
  * Wrapper for {@link com.google.api.services.calendar.model.EventAttendee}
  * to make it data mapper friendly.
@@ -104,7 +106,7 @@ public class EventAttendee extends BaseWrapper<com.google.api.services.calendar.
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 }

--- a/src/main/java/org/mule/module/google/calendar/model/EventDateTime.java
+++ b/src/main/java/org/mule/module/google/calendar/model/EventDateTime.java
@@ -32,7 +32,7 @@ public class EventDateTime extends BaseWrapper<com.google.api.services.calendar.
 	}
 
 	public String getDate() {
-		return wrapped.getDate().toString();
+		return wrapped.getDate() != null ? wrapped.getDate().toString() : "";
 	}
 
 	public String getTimeZone() {

--- a/src/main/java/org/mule/module/google/calendar/model/EventDateTime.java
+++ b/src/main/java/org/mule/module/google/calendar/model/EventDateTime.java
@@ -13,6 +13,8 @@ package org.mule.module.google.calendar.model;
 import org.mule.modules.google.api.datetime.DateTime;
 import org.mule.modules.google.api.model.BaseWrapper;
 
+import java.io.IOException;
+
 /**
  * Wrapper for {@link com.google.api.services.calendar.model.EventDateTime}
  * to make it data mapper friendly.
@@ -30,7 +32,7 @@ public class EventDateTime extends BaseWrapper<com.google.api.services.calendar.
 	}
 
 	public String getDate() {
-		return wrapped.getDate();
+		return wrapped.getDate().toString();
 	}
 
 	public String getTimeZone() {
@@ -50,7 +52,7 @@ public class EventDateTime extends BaseWrapper<com.google.api.services.calendar.
 	}
 
 	public void setDate(String date) {
-		wrapped.setDate(date);
+		wrapped.setDate(new com.google.api.client.util.DateTime(date));
 	}
 
 	public void setTimeZone(String timeZone) {
@@ -65,7 +67,7 @@ public class EventDateTime extends BaseWrapper<com.google.api.services.calendar.
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 }

--- a/src/main/java/org/mule/module/google/calendar/model/EventReminder.java
+++ b/src/main/java/org/mule/module/google/calendar/model/EventReminder.java
@@ -12,6 +12,8 @@ package org.mule.module.google.calendar.model;
 
 import org.mule.modules.google.api.model.BaseWrapper;
 
+import java.io.IOException;
+
 
 /**
  * Wrapper for {@link com.google.api.services.calendar.model.EventReminder}
@@ -57,7 +59,7 @@ public class EventReminder extends BaseWrapper<com.google.api.services.calendar.
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 }

--- a/src/main/java/org/mule/module/google/calendar/model/ExtendedProperties.java
+++ b/src/main/java/org/mule/module/google/calendar/model/ExtendedProperties.java
@@ -10,6 +10,7 @@
 
 package org.mule.module.google.calendar.model;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.mule.modules.google.api.model.BaseWrapper;
@@ -34,7 +35,7 @@ public class ExtendedProperties extends BaseWrapper<com.google.api.services.cale
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 

--- a/src/main/java/org/mule/module/google/calendar/model/FreeBusy.java
+++ b/src/main/java/org/mule/module/google/calendar/model/FreeBusy.java
@@ -10,6 +10,7 @@
 
 package org.mule.module.google.calendar.model;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.mule.modules.google.api.datetime.DateTime;
@@ -79,7 +80,7 @@ public class FreeBusy extends BaseWrapper<FreeBusyResponse> {
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 }

--- a/src/main/java/org/mule/module/google/calendar/model/FreeBusy.java
+++ b/src/main/java/org/mule/module/google/calendar/model/FreeBusy.java
@@ -83,4 +83,6 @@ public class FreeBusy extends BaseWrapper<FreeBusyResponse> {
 	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
+
+
 }

--- a/src/main/java/org/mule/module/google/calendar/model/Organizer.java
+++ b/src/main/java/org/mule/module/google/calendar/model/Organizer.java
@@ -12,6 +12,8 @@ package org.mule.module.google.calendar.model;
 
 import org.mule.modules.google.api.model.BaseWrapper;
 
+import java.io.IOException;
+
 /**
  * Wrapper for {@link com.google.api.services.calendar.model.Event.Organizer}
  * to make it data mapper friendly.
@@ -64,7 +66,7 @@ public class Organizer extends BaseWrapper<com.google.api.services.calendar.mode
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 }

--- a/src/main/java/org/mule/module/google/calendar/model/Reminders.java
+++ b/src/main/java/org/mule/module/google/calendar/model/Reminders.java
@@ -10,6 +10,7 @@
 
 package org.mule.module.google.calendar.model;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.mule.modules.google.api.model.BaseWrapper;
@@ -59,7 +60,7 @@ public class Reminders extends BaseWrapper<com.google.api.services.calendar.mode
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 }

--- a/src/main/java/org/mule/module/google/calendar/model/Scope.java
+++ b/src/main/java/org/mule/module/google/calendar/model/Scope.java
@@ -12,6 +12,8 @@ package org.mule.module.google.calendar.model;
 
 import org.mule.modules.google.api.model.BaseWrapper;
 
+import java.io.IOException;
+
 
 /**
  * Wrapper for {@link com.google.api.services.calendar.model.AclRule.Scope}
@@ -57,7 +59,7 @@ public class Scope extends BaseWrapper<com.google.api.services.calendar.model.Ac
 		return wrapped.toString();
 	}
 
-	public String toPrettyString() {
+	public String toPrettyString() throws IOException{
 		return wrapped.toPrettyString();
 	}
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/RegressionTestSuite.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/RegressionTestSuite.java
@@ -14,56 +14,26 @@ import org.junit.experimental.categories.Categories;
 import org.junit.experimental.categories.Categories.IncludeCategory;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
-import org.mule.module.google.calendar.automation.testcases.BatchDeleteCalendarTestCases;
-import org.mule.module.google.calendar.automation.testcases.BatchDeleteEventTestCases;
-import org.mule.module.google.calendar.automation.testcases.BatchInsertCalendarTestCases;
-import org.mule.module.google.calendar.automation.testcases.BatchInsertEventTestCases;
-import org.mule.module.google.calendar.automation.testcases.BatchUpdateCalendarTestCases;
-import org.mule.module.google.calendar.automation.testcases.BatchUpdateEventTestCases;
-import org.mule.module.google.calendar.automation.testcases.ClearCalendarTestCases;
-import org.mule.module.google.calendar.automation.testcases.CreateCalendarTestCases;
-import org.mule.module.google.calendar.automation.testcases.DeleteAclRuleTestCases;
-import org.mule.module.google.calendar.automation.testcases.DeleteCalendarListTestCases;
-import org.mule.module.google.calendar.automation.testcases.DeleteCalendarTestCases;
-import org.mule.module.google.calendar.automation.testcases.DeleteEventTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetAclRuleByIdTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetAllAclRulesTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetCalendarByIdTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetCalendarListByIdTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetCalendarListTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetEventByIdTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetEventsTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetFreeTimeTestCases;
-import org.mule.module.google.calendar.automation.testcases.GetInstancesTestCases;
-import org.mule.module.google.calendar.automation.testcases.ImportEventTestCases;
-import org.mule.module.google.calendar.automation.testcases.InsertAclRuleTestCases;
-import org.mule.module.google.calendar.automation.testcases.InsertEventTestCases;
-import org.mule.module.google.calendar.automation.testcases.MoveEventTestCases;
-import org.mule.module.google.calendar.automation.testcases.QuickAddEventTestCases;
-import org.mule.module.google.calendar.automation.testcases.RegressionTests;
-import org.mule.module.google.calendar.automation.testcases.UpdateAclRuleTestCases;
-import org.mule.module.google.calendar.automation.testcases.UpdateCalendarListTestCases;
-import org.mule.module.google.calendar.automation.testcases.UpdateCalendarTestCases;
-import org.mule.module.google.calendar.automation.testcases.UpdateEventTestCases;
+import org.mule.module.google.calendar.automation.testcases.*;
 
 @RunWith(Categories.class)
 @IncludeCategory(RegressionTests.class)
 @SuiteClasses({
-	BatchDeleteCalendarTestCases.class, BatchDeleteEventTestCases.class,
-	BatchInsertCalendarTestCases.class, BatchInsertEventTestCases.class,
-	BatchUpdateCalendarTestCases.class, BatchUpdateEventTestCases.class,
-	ClearCalendarTestCases.class, DeleteAclRuleTestCases.class,
-	DeleteCalendarListTestCases.class, DeleteCalendarTestCases.class,
-	DeleteEventTestCases.class, GetAclRuleByIdTestCases.class,
-	GetAllAclRulesTestCases.class, GetCalendarByIdTestCases.class,
-	GetCalendarListByIdTestCases.class, GetCalendarListTestCases.class,
-	GetEventByIdTestCases.class, GetEventsTestCases.class,
-	GetFreeTimeTestCases.class, GetInstancesTestCases.class,
-	ImportEventTestCases.class, InsertAclRuleTestCases.class,
-	InsertEventTestCases.class, MoveEventTestCases.class,
-	QuickAddEventTestCases.class, UpdateAclRuleTestCases.class,
-	UpdateCalendarListTestCases.class, UpdateCalendarTestCases.class,
-	UpdateEventTestCases.class, CreateCalendarTestCases.class
+        BatchDeleteCalendarTestCases.class, BatchDeleteEventTestCases.class,
+        BatchInsertCalendarTestCases.class, BatchInsertEventTestCases.class,
+        BatchUpdateCalendarTestCases.class, BatchUpdateEventTestCases.class,
+        ClearCalendarTestCases.class, DeleteAclRuleTestCases.class,
+        DeleteCalendarListTestCases.class, DeleteCalendarTestCases.class,
+        DeleteEventTestCases.class, GetAclRuleByIdTestCases.class,
+        GetAllAclRulesTestCases.class, GetCalendarByIdTestCases.class,
+        GetCalendarListByIdTestCases.class, GetCalendarListTestCases.class,
+        GetEventByIdTestCases.class, GetEventsTestCases.class,
+        GetFreeTimeTestCases.class, GetInstancesTestCases.class,
+        ImportEventTestCases.class, InsertAclRuleTestCases.class,
+        InsertEventTestCases.class, MoveEventTestCases.class,
+        QuickAddEventTestCases.class, UpdateAclRuleTestCases.class,
+        UpdateCalendarListTestCases.class, UpdateCalendarTestCases.class,
+        UpdateEventTestCases.class, CreateCalendarTestCases.class
 })
 public class RegressionTestSuite {
 

--- a/src/test/java/org/mule/module/google/calendar/automation/SmokeTestSuite.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/SmokeTestSuite.java
@@ -48,21 +48,22 @@ import org.mule.module.google.calendar.automation.testcases.UpdateEventTestCases
 
 @RunWith(Categories.class)
 @IncludeCategory(SmokeTests.class)
-@SuiteClasses({ BatchDeleteCalendarTestCases.class,
-		BatchDeleteEventTestCases.class, 
-		BatchInsertCalendarTestCases.class,
-		BatchInsertEventTestCases.class,
-		CreateCalendarTestCases.class, 
-		DeleteAclRuleTestCases.class,
-		DeleteCalendarTestCases.class, 
-		DeleteEventTestCases.class,
-		GetAclRuleByIdTestCases.class, 
-		GetCalendarByIdTestCases.class,
-		GetCalendarListByIdTestCases.class, 
-		GetCalendarListTestCases.class,
-		GetEventByIdTestCases.class, 
-		GetEventsTestCases.class,
-		InsertAclRuleTestCases.class, 
-		InsertEventTestCases.class})
+@SuiteClasses({
+        BatchDeleteCalendarTestCases.class,
+        BatchDeleteEventTestCases.class,
+        BatchInsertCalendarTestCases.class,
+        BatchInsertEventTestCases.class,
+        CreateCalendarTestCases.class,
+        DeleteAclRuleTestCases.class,
+        DeleteCalendarTestCases.class,
+        DeleteEventTestCases.class,
+        GetAclRuleByIdTestCases.class,
+        GetCalendarByIdTestCases.class,
+        GetCalendarListByIdTestCases.class,
+        GetCalendarListTestCases.class,
+        GetEventByIdTestCases.class,
+        GetEventsTestCases.class,
+        InsertAclRuleTestCases.class,
+        InsertEventTestCases.class})
 public class SmokeTestSuite {
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchDeleteCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchDeleteCalendarTestCases.java
@@ -10,67 +10,64 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Lists;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.automation.CalendarUtils;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
+import org.mule.streaming.ConsumerIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 public class BatchDeleteCalendarTestCases extends GoogleCalendarTestParent {
 
-	protected List<Calendar> insertedCalendars = new ArrayList<Calendar>();
+    protected List<Calendar> insertedCalendars = new ArrayList<Calendar>();
 
-	@Before
-	public void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
 
-		loadTestRunMessage("batchDeleteCalendar");
-		
-		Integer numCalendars = getTestRunMessageValue("numCalendars");
-		
-		// Create calendar instances
-		List<Calendar> calendars = new ArrayList<Calendar>();
-		for (int i = 0; i < numCalendars; i++) {
-			calendars.add(CalendarUtils.getCalendar("This is a title"));
-		}
+        initializeTestRunMessage("batchDeleteCalendar");
 
-		// Insert calendar
-		BatchResponse<Calendar> response = insertCalendars(calendars);			
-		
-		// Add them to a global variable so that we can drop them in the tearDown method
-		for (Calendar calendar : response.getSuccessful()) {
-			insertedCalendars.add(calendar);
-		}
-		
-	}
-		
-	@Ignore("Needs to be review")
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testBatchDeleteCalendar() {
-		try {
-			deleteCalendars(insertedCalendars);
+        Integer numCalendars = getTestRunMessageValue("numCalendars");
 
-			List<CalendarList> calendarList = runFlowAndGetPayload("get-calendar-list");
-			for (Calendar calendar : insertedCalendars) {
-				assertFalse(CalendarUtils.isCalendarInList(calendarList, calendar));
-			}
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
+        // Create calendar instances
+        List<Calendar> calendars = new ArrayList<Calendar>();
+        for (int i = 0; i < numCalendars; i++) {
+            calendars.add(CalendarUtils.getCalendar("This is a title"));
+        }
+
+        // Insert calendar
+        BatchResponse<Calendar> response = insertCalendars(calendars);
+
+        // Add them to a global variable so that we can drop them in the tearDown method
+        for (Calendar calendar : response.getSuccessful()) {
+            insertedCalendars.add(calendar);
+        }
+
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testBatchDeleteCalendar() {
+        try {
+            deleteCalendars(insertedCalendars);
+
+            ConsumerIterator<CalendarList> consumerIterator = runFlowAndGetPayload("get-calendar-list");
+            List<CalendarList> calendarList = Lists.newArrayList(consumerIterator);
+            for (Calendar calendar : insertedCalendars) {
+                assertFalse(CalendarUtils.isCalendarInList(calendarList, calendar));
+            }
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchDeleteCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchDeleteCalendarTestCases.java
@@ -19,9 +19,9 @@ import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
-import org.mule.streaming.ConsumerIterator;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
@@ -60,7 +60,7 @@ public class BatchDeleteCalendarTestCases extends GoogleCalendarTestParent {
         try {
             deleteCalendars(insertedCalendars);
 
-            ConsumerIterator<CalendarList> consumerIterator = runFlowAndGetPayload("get-calendar-list");
+            Iterator<CalendarList> consumerIterator = runFlowAndGetPayload("get-calendar-list");
             List<CalendarList> calendarList = Lists.newArrayList(consumerIterator);
             for (Calendar calendar : insertedCalendars) {
                 assertFalse(CalendarUtils.isCalendarInList(calendarList, calendar));

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchDeleteEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchDeleteEventTestCases.java
@@ -10,13 +10,10 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mule.module.google.calendar.automation.CalendarUtils;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.module.google.calendar.model.EventDateTime;
 import org.mule.modules.google.api.client.batch.BatchResponse;
@@ -31,7 +28,6 @@ import static org.junit.Assert.fail;
 
 public class BatchDeleteEventTestCases extends GoogleCalendarTestParent {
 
-    @Ignore("Needs to be review")
     @Before
     public void setUp() throws Exception {
 

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchDeleteEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchDeleteEventTestCases.java
@@ -10,85 +10,83 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.automation.CalendarUtils;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.module.google.calendar.model.EventDateTime;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
+import org.mule.streaming.ConsumerIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class BatchDeleteEventTestCases extends GoogleCalendarTestParent {
 
-	@Ignore("Needs to be review")
-	@Before
-	public void setUp() throws Exception {
-		
-		loadTestRunMessage("batchDeleteEvent");
+    @Before
+    public void setUp() throws Exception {
 
-		// Insert calendar and get reference to retrieved calendar
-		Calendar calendar = runFlowAndGetPayload("create-calendar");
-		
-		// Replace old calendar instance with new instance
-		upsertOnTestRunMessage("calendarRef", calendar);
-		upsertOnTestRunMessage("calendarId", calendar.getId());			
+        initializeTestRunMessage("batchDeleteEvent");
 
-		// Get the sample event
-		Event sampleEvent = getTestRunMessageValue("sampleEvent");
-		
-		// Get start and end time beans.
-		EventDateTime eventStartTime = sampleEvent.getStart();
-		EventDateTime eventEndTime = sampleEvent.getEnd();
-		Integer numEvents = getTestRunMessageValue("numEvents");
-		
-		// Instantiate the events that we want to batch insert
-		List<Event> events = new ArrayList<Event>();
-		for (int i = 0; i < numEvents; i++) {
-			Event event = CalendarUtils.getEvent("Test Event", eventStartTime, eventEndTime);
-			events.add(event);
-		}
-		
-		// Store the successfully persisted events in testObjects for later access
-		BatchResponse<Event> batchResponse = insertEvents(calendar, events);
-		List<Event> successful = batchResponse.getSuccessful();
-		upsertOnTestRunMessage("calendarEventsRef", successful);
-		
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testBatchDeleteEvent() {
-		try {			
-						
-			Calendar calendar = getTestRunMessageValue("calendarRef");
-			List<Event> succcessful = getTestRunMessageValue("calendarEventsRef");
-			 
-			deleteEvents(calendar, succcessful);
-			
-			List<Event> events = runFlowAndGetPayload("get-all-events");
-			assertTrue(events.isEmpty());
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
-	}
-	
+        // Insert calendar and get reference to retrieved calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+        // Replace old calendar instance with new instance
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+        // Get the sample event
+        Event sampleEvent = getTestRunMessageValue("sampleEvent");
+
+        // Get start and end time beans.
+        EventDateTime eventStartTime = sampleEvent.getStart();
+        EventDateTime eventEndTime = sampleEvent.getEnd();
+        Integer numEvents = getTestRunMessageValue("numEvents");
+
+        // Instantiate the events that we want to batch insert
+        List<Event> events = new ArrayList<Event>();
+        for (int i = 0; i < numEvents; i++) {
+            Event event = CalendarUtils.getEvent("Test Event", eventStartTime, eventEndTime);
+            events.add(event);
+        }
+
+        // Store the successfully persisted events in testObjects for later access
+        BatchResponse<Event> batchResponse = insertEvents(calendar, events);
+        List<Event> successful = batchResponse.getSuccessful();
+        upsertOnTestRunMessage("calendarEventsRef", successful);
+
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testBatchDeleteEvent() {
+        try {
+
+            Calendar calendar = getTestRunMessageValue("calendarRef");
+            List<Event> successful = getTestRunMessageValue("calendarEventsRef");
+
+            deleteEvents(calendar, successful);
+
+            ConsumerIterator<Event> consumerIterator = runFlowAndGetPayload("get-all-events");
+            List<Event> events = Lists.newArrayList(consumerIterator);
+            assertTrue(events.isEmpty());
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchInsertCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchInsertCalendarTestCases.java
@@ -10,15 +10,7 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mule.module.google.calendar.automation.CalendarUtils;
@@ -26,45 +18,50 @@ import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class BatchInsertCalendarTestCases extends GoogleCalendarTestParent {
 
-	protected List<Calendar> insertedCalendars = new ArrayList<Calendar>();
-	
-	@Ignore("Needs to be review")
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testBatchInsertCalendar() {
-		try {
-			loadTestRunMessage("batchInsertCalendar");
-			
-			Integer numCalendars = getTestRunMessageValue("numCalendars");
-			
-			// Create calendar instances
-			List<Calendar> calendars = new ArrayList<Calendar>();
-			for (int i = 0; i < numCalendars; i++) {
-				calendars.add(CalendarUtils.getCalendar("This is a title"));
-			}
-	
-			// Insert calendars
-			BatchResponse<Calendar> response = insertCalendars(calendars);			
-			
-			// Assert that no errors exist in the response
-			assertTrue(response.getErrors() == null || response.getErrors().size() == 0);
-			assertTrue(response.getSuccessful().size() == numCalendars);
-			
-			// Add them to a global variable so that we can drop them in the tearDown method
-			for (Calendar calendar : response.getSuccessful()) {
-				insertedCalendars.add(calendar);
-			}
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-		
-	@After
-	public void tearDown() throws Exception {
-		deleteCalendars(insertedCalendars);			
-	}
-	
+    protected List<Calendar> insertedCalendars = new ArrayList<Calendar>();
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testBatchInsertCalendar() {
+        try {
+            initializeTestRunMessage("batchInsertCalendar");
+
+            Integer numCalendars = getTestRunMessageValue("numCalendars");
+
+            // Create calendar instances
+            List<Calendar> calendars = new ArrayList<Calendar>();
+            for (int i = 0; i < numCalendars; i++) {
+                calendars.add(CalendarUtils.getCalendar("This is a title"));
+            }
+
+            // Insert calendars
+            BatchResponse<Calendar> response = insertCalendars(calendars);
+
+            // Assert that no errors exist in the response
+            assertTrue(response.getErrors() == null || response.getErrors().size() == 0);
+            assertTrue(response.getSuccessful().size() == numCalendars);
+
+            // Add them to a global variable so that we can drop them in the tearDown method
+            for (Calendar calendar : response.getSuccessful()) {
+                insertedCalendars.add(calendar);
+            }
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        deleteCalendars(insertedCalendars);
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchInsertEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchInsertEventTestCases.java
@@ -10,12 +10,6 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,62 +21,66 @@ import org.mule.module.google.calendar.model.EventDateTime;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class BatchInsertEventTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-		try {
-			loadTestRunMessage("batchInsertEvent");
+    @Before
+    public void setUp() throws Exception {
+        try {
+            initializeTestRunMessage("batchInsertEvent");
 
-			// Insert calendar and get reference to retrieved calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Replace old calendar instance with new instance
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail();
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-		String calendarId = getTestRunMessageValue("calendarId");
-		deleteCalendar(calendarId);
+            // Insert calendar and get reference to retrieved calendar
+            Calendar calendar = runFlowAndGetPayload("create-calendar");
 
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testBatchInsertEvent() {
-		try {			
-			
-			Event sampleEvent = getTestRunMessageValue("sampleEvent");
-			
-			// Get start and end time beans.
-			String eventSummary = sampleEvent.getSummary();
-			EventDateTime eventStartTime = sampleEvent.getStart();
-			EventDateTime eventEndTime = sampleEvent.getEnd();			
-			Integer numEvents = getTestRunMessageValue("numEvents");
-			String calendarId = getTestRunMessageValue("calendarId");
-			
-			// Instantiate the events that we want to batch insert
-			List<Event> events = new ArrayList<Event>();
-			for (int i = 0; i < numEvents; i++) {
-				Event event = CalendarUtils.getEvent(eventSummary, eventStartTime, eventEndTime);
-				events.add(event);
-			}
-		
-			// Batch insert the events
-			BatchResponse<Event> batchResponse = insertEvents(calendarId, events);
-			assertTrue(batchResponse.getErrors() == null || batchResponse.getErrors().size() == 0);
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
+            // Replace old calendar instance with new instance
+            upsertOnTestRunMessage("calendarRef", calendar);
+            upsertOnTestRunMessage("calendarId", calendar.getId());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testBatchInsertEvent() {
+        try {
+
+            Event sampleEvent = getTestRunMessageValue("sampleEvent");
+
+            // Get start and end time beans.
+            String eventSummary = sampleEvent.getSummary();
+            EventDateTime eventStartTime = sampleEvent.getStart();
+            EventDateTime eventEndTime = sampleEvent.getEnd();
+            Integer numEvents = getTestRunMessageValue("numEvents");
+            String calendarId = getTestRunMessageValue("calendarId");
+
+            // Instantiate the events that we want to batch insert
+            List<Event> events = new ArrayList<Event>();
+            for (int i = 0; i < numEvents; i++) {
+                Event event = CalendarUtils.getEvent(eventSummary, eventStartTime, eventEndTime);
+                events.add(event);
+            }
+
+            // Batch insert the events
+            BatchResponse<Event> batchResponse = insertEvents(calendarId, events);
+            assertTrue(batchResponse.getErrors() == null || batchResponse.getErrors().size() == 0);
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
 }
-	

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchUpdateCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchUpdateCalendarTestCases.java
@@ -79,6 +79,5 @@ public class BatchUpdateCalendarTestCases extends GoogleCalendarTestParent {
     public void tearDown() throws Exception {
         List<Calendar> calendars = getTestRunMessageValue("calendarsRef");
         deleteCalendars(calendars);
-
     }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchUpdateCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchUpdateCalendarTestCases.java
@@ -10,78 +10,75 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.automation.CalendarUtils;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class BatchUpdateCalendarTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("batchUpdateCalendar");
-			
-			Integer numCalendars =getTestRunMessageValue("numCalendars");
-			String summaryBefore = getTestRunMessageValue("summaryBefore");
-			
-			List<Calendar> calendars = new ArrayList<Calendar>();
-			for (int i = 0; i < numCalendars; i++) {
-				Calendar calendar = CalendarUtils.getCalendar(summaryBefore);
-				calendars.add(calendar);
-			}
-			
-			BatchResponse<Calendar> calendarBatchResponse = insertCalendars(calendars);
-			List<Calendar> insertedCalendars = calendarBatchResponse.getSuccessful();
-			
-			upsertOnTestRunMessage("calendars", insertedCalendars);
-	}
-	
-	@Category({ RegressionTests.class})	
-	@Test
-	public void testBatchUpdateCalendar() {
-		try {
-			List<Calendar> calendars = getTestRunMessageValue("calendars");
-			String summaryAfter = getTestRunMessageValue("summaryAfter");
-			
-			for (Calendar calendar : calendars) {
-				calendar.setSummary(summaryAfter);
-			}
-			
-			upsertOnTestRunMessage("calendarsRef", calendars);
-			BatchResponse<Calendar> updatedCalendars = runFlowAndGetPayload("batch-update-calendar");
-			assertTrue(updatedCalendars.getErrors() == null || updatedCalendars.getErrors().size() == 0);
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("batchUpdateCalendar");
 
-			List<Calendar> successful = updatedCalendars.getSuccessful();
-			
-			for (Calendar cal : successful) {
-				cal.getSummary().equals(summaryAfter);
-			}
-			
-			assertTrue(EqualsBuilder.reflectionEquals(successful, calendars));
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-		List<Calendar> calendars = getTestRunMessageValue("calendarsRef");
-		deleteCalendars(calendars);
-	
-	}
+        Integer numCalendars = getTestRunMessageValue("numCalendars");
+        String summaryBefore = getTestRunMessageValue("summaryBefore");
+
+        List<Calendar> calendars = new ArrayList<Calendar>();
+        for (int i = 0; i < numCalendars; i++) {
+            Calendar calendar = CalendarUtils.getCalendar(summaryBefore);
+            calendars.add(calendar);
+        }
+
+        BatchResponse<Calendar> calendarBatchResponse = insertCalendars(calendars);
+        List<Calendar> insertedCalendars = calendarBatchResponse.getSuccessful();
+
+        upsertOnTestRunMessage("calendars", insertedCalendars);
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testBatchUpdateCalendar() {
+        try {
+            List<Calendar> calendars = getTestRunMessageValue("calendars");
+            String summaryAfter = getTestRunMessageValue("summaryAfter");
+
+            for (Calendar calendar : calendars) {
+                calendar.setSummary(summaryAfter);
+            }
+
+            upsertOnTestRunMessage("calendarsRef", calendars);
+            BatchResponse<Calendar> updatedCalendars = runFlowAndGetPayload("batch-update-calendar");
+            assertTrue(updatedCalendars.getErrors() == null || updatedCalendars.getErrors().size() == 0);
+
+            List<Calendar> successful = updatedCalendars.getSuccessful();
+
+            for (Calendar cal : successful) {
+                cal.getSummary().equals(summaryAfter);
+            }
+
+            assertTrue(EqualsBuilder.reflectionEquals(successful, calendars));
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        List<Calendar> calendars = getTestRunMessageValue("calendarsRef");
+        deleteCalendars(calendars);
+
+    }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchUpdateEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchUpdateEventTestCases.java
@@ -35,10 +35,6 @@ public class BatchUpdateEventTestCases extends GoogleCalendarTestParent {
 
         initializeTestRunMessage("batchUpdateEvent");
 
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-        upsertOnTestRunMessage("calendar", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
-
         EventDateTime eventTimeStart = getTestRunMessageValue("eventStart");
         EventDateTime eventTimeEnd = getTestRunMessageValue("eventEnd");
         String summaryBefore = getTestRunMessageValue("summaryBefore");
@@ -50,7 +46,7 @@ public class BatchUpdateEventTestCases extends GoogleCalendarTestParent {
             events.add(event);
         }
 
-        BatchResponse<Event> batchEvents = insertEvents(calendar, events);
+        BatchResponse<Event> batchEvents = insertEvents(events);
         List<Event> successfulEvents = batchEvents.getSuccessful();
 
         upsertOnTestRunMessage("events", successfulEvents);
@@ -81,6 +77,8 @@ public class BatchUpdateEventTestCases extends GoogleCalendarTestParent {
 
             assertTrue(EqualsBuilder.reflectionEquals(successfulEvents, events));
 
+            upsertOnTestRunMessage("calendarEventsRef", successfulEvents);
+
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
@@ -88,10 +86,7 @@ public class BatchUpdateEventTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-
-        Calendar calendar = getTestRunMessageValue("calendar");
-        deleteCalendar(calendar);
-
+        runFlowAndGetPayload("batch-delete-event");
     }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchUpdateEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/BatchUpdateEventTestCases.java
@@ -10,20 +10,11 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.automation.CalendarUtils;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
@@ -31,70 +22,76 @@ import org.mule.module.google.calendar.model.EventDateTime;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class BatchUpdateEventTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-		
-			loadTestRunMessage("batchUpdateEvent");
-			
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			upsertOnTestRunMessage("calendar", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
+    @Before
+    public void setUp() throws Exception {
 
-			EventDateTime eventTimeStart = getTestRunMessageValue("eventStart");
-			EventDateTime eventTimeEnd = getTestRunMessageValue("eventEnd");
-			String summaryBefore = getTestRunMessageValue("summaryBefore");
-			Integer numEvents =getTestRunMessageValue("numEvents");
-			
-			List<Event> events = new ArrayList<Event>();
-			for (int i = 0; i < numEvents; i++) {
-				Event event = CalendarUtils.getEvent(summaryBefore, eventTimeStart, eventTimeEnd);
-				events.add(event);
-			}
-			
-			BatchResponse<Event> batchEvents = insertEvents(calendar, events);
-			List<Event> successfulEvents = batchEvents.getSuccessful();
-			
-			upsertOnTestRunMessage("events", successfulEvents);
-			
-	}
-	
-	@Category({ RegressionTests.class})	
-	@Test
-	public void testBatchUpdateEvent() {
-		try {
-			
-			String summaryAfter = getTestRunMessageValue("summaryAfter");
-			List<Event> events = (List<Event>) getTestRunMessageValue("events");
-			
-			for (Event event : events) {
-				event.setSummary(summaryAfter);
-			}
-			
-			upsertOnTestRunMessage("calendarEventsRef", events);
-			BatchResponse<Event> returnedEvents = runFlowAndGetPayload("batch-update-event");
-			assertTrue(returnedEvents.getErrors() == null || returnedEvents.getErrors().size() == 0);
-			
-			List<Event> successfulEvents = returnedEvents.getSuccessful();
-			assertTrue(successfulEvents.size() == events.size());
-			for (Event successfulEvent : successfulEvents) {
-				assertTrue(CalendarUtils.isEventInList(events, successfulEvent));
-			}
-			
-			assertTrue(EqualsBuilder.reflectionEquals(successfulEvents, events));
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
+        initializeTestRunMessage("batchUpdateEvent");
 
-	@After
-	public void tearDown() throws Exception {
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+        upsertOnTestRunMessage("calendar", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
 
-		Calendar calendar = getTestRunMessageValue("calendar");
-		deleteCalendar(calendar);
+        EventDateTime eventTimeStart = getTestRunMessageValue("eventStart");
+        EventDateTime eventTimeEnd = getTestRunMessageValue("eventEnd");
+        String summaryBefore = getTestRunMessageValue("summaryBefore");
+        Integer numEvents = getTestRunMessageValue("numEvents");
 
-	}
-	
+        List<Event> events = new ArrayList<Event>();
+        for (int i = 0; i < numEvents; i++) {
+            Event event = CalendarUtils.getEvent(summaryBefore, eventTimeStart, eventTimeEnd);
+            events.add(event);
+        }
+
+        BatchResponse<Event> batchEvents = insertEvents(calendar, events);
+        List<Event> successfulEvents = batchEvents.getSuccessful();
+
+        upsertOnTestRunMessage("events", successfulEvents);
+
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testBatchUpdateEvent() {
+        try {
+
+            String summaryAfter = getTestRunMessageValue("summaryAfter");
+            List<Event> events = (List<Event>) getTestRunMessageValue("events");
+
+            for (Event event : events) {
+                event.setSummary(summaryAfter);
+            }
+
+            upsertOnTestRunMessage("calendarEventsRef", events);
+            BatchResponse<Event> returnedEvents = runFlowAndGetPayload("batch-update-event");
+            assertTrue(returnedEvents.getErrors() == null || returnedEvents.getErrors().size() == 0);
+
+            List<Event> successfulEvents = returnedEvents.getSuccessful();
+            assertTrue(successfulEvents.size() == events.size());
+            for (Event successfulEvent : successfulEvents) {
+                assertTrue(CalendarUtils.isEventInList(events, successfulEvent));
+            }
+
+            assertTrue(EqualsBuilder.reflectionEquals(successfulEvents, events));
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        Calendar calendar = getTestRunMessageValue("calendar");
+        deleteCalendar(calendar);
+
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/ClearCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/ClearCalendarTestCases.java
@@ -10,25 +10,20 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mule.module.google.calendar.automation.CalendarUtils;
+import org.mule.module.google.calendar.model.Event;
+import org.mule.modules.google.api.client.batch.BatchResponse;
+import org.mule.modules.tests.ConnectorTestUtils;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
-import org.mule.module.google.calendar.automation.CalendarUtils;
-import org.mule.module.google.calendar.model.Calendar;
-import org.mule.module.google.calendar.model.Event;
-import org.mule.modules.google.api.client.batch.BatchResponse;
-import org.mule.modules.tests.ConnectorTestUtils;
-import org.mule.streaming.ConsumerIterator;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 public class ClearCalendarTestCases extends GoogleCalendarTestParent {
 

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/ClearCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/ClearCalendarTestCases.java
@@ -10,69 +10,66 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.After;
+import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.automation.CalendarUtils;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
+import org.mule.streaming.ConsumerIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ClearCalendarTestCases extends GoogleCalendarTestParent {
 
-	@SuppressWarnings("unchecked")
-	@Before
-	public void setUp() throws Exception {
-		
-		loadTestRunMessage("clearCalendar");
-					
-		String primaryCalendarId = getTestRunMessageValue("id");
-		Event sampleEvent = getTestRunMessageValue("sampleEvent");
-		Integer numEvents = getTestRunMessageValue("numEvents");
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
 
-		// Instantiate the event objects
-		List<Event> events = new ArrayList<Event>();
-		for (int i = 0; i < numEvents; i++) {
-			events.add(CalendarUtils.getEvent(sampleEvent.getSummary(), sampleEvent.getStart(), sampleEvent.getEnd()));
-		}
-				
-		// Batch insert the events
-		BatchResponse<Event> batchResponse = insertEvents(primaryCalendarId, events);
-		List<Event> successfulEvents = batchResponse.getSuccessful();
-		
-		upsertOnTestRunMessage("events", successfulEvents);
+        initializeTestRunMessage("clearCalendar");
 
-	}
-	
-	@Category({ RegressionTests.class})
-	@Test
-	public void testClearCalendar() {
-		try {
-			String primaryCalendarId = getTestRunMessageValue("id");			
-			
-			// Clear the calendar
-			runFlowAndGetPayload("clear-calendar");
+        String primaryCalendarId = getTestRunMessageValue("id");
+        Event sampleEvent = getTestRunMessageValue("sampleEvent");
+        Integer numEvents = getTestRunMessageValue("numEvents");
 
-			// Get all events
-			upsertOnTestRunMessage("calendarId", primaryCalendarId);
-			List<Event> returnedEvents = runFlowAndGetPayload("get-all-events");
-			
-			// Assert that no events are returned
-			assertTrue(returnedEvents.isEmpty());
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
+        // Instantiate the event objects
+        List<Event> events = new ArrayList<Event>();
+        for (int i = 0; i < numEvents; i++) {
+            events.add(CalendarUtils.getEvent(sampleEvent.getSummary(), sampleEvent.getStart(), sampleEvent.getEnd()));
+        }
+
+        // Batch insert the events
+        BatchResponse<Event> batchResponse = insertEvents(primaryCalendarId, events);
+        List<Event> successfulEvents = batchResponse.getSuccessful();
+
+        upsertOnTestRunMessage("events", successfulEvents);
+
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testClearCalendar() {
+        try {
+            String primaryCalendarId = getTestRunMessageValue("id");
+
+            // Clear the calendar
+            runFlowAndGetPayload("clear-calendar");
+
+            // Get all events
+            upsertOnTestRunMessage("calendarId", primaryCalendarId);
+            ConsumerIterator<Event> returnedEvents = runFlowAndGetPayload("get-all-events");
+
+            // Assert that no events are returned
+            assertTrue(Lists.newArrayList(returnedEvents).isEmpty());
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
 }
 

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/CreateCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/CreateCalendarTestCases.java
@@ -41,7 +41,7 @@ public class CreateCalendarTestCases extends GoogleCalendarTestParent {
             assertTrue(createdCalendar != null);
             assertTrue(createdCalendar.getSummary().equals(originalCalendar.getSummary()));
 
-            upsertOnTestRunMessage("id", createdCalendar.getId());
+            upsertOnTestRunMessage("calendarId", createdCalendar.getId());
 
             Calendar returnedCalendar = runFlowAndGetPayload("get-calendar-by-id");
             assertTrue(returnedCalendar != null);

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/CreateCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/CreateCalendarTestCases.java
@@ -10,57 +10,52 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class CreateCalendarTestCases extends GoogleCalendarTestParent {
 
-	@SuppressWarnings("unchecked")
-	@Before
-	public void setUp() throws Exception {
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
 
-			loadTestRunMessage("createCalendar");
+        initializeTestRunMessage("createCalendar");
 
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testCreateCalendar() {
-		try {
-			
-			Calendar originalCalendar = getTestRunMessageValue("calendarRef");
-			Calendar createdCalendar = runFlowAndGetPayload("create-calendar");
+    }
 
-			assertTrue(createdCalendar != null);
-			assertTrue(createdCalendar.getSummary().equals(originalCalendar.getSummary()));
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testCreateCalendar() {
+        try {
 
-			upsertOnTestRunMessage("id", createdCalendar.getId());
+            Calendar originalCalendar = getTestRunMessageValue("calendarRef");
+            Calendar createdCalendar = runFlowAndGetPayload("create-calendar");
 
-			Calendar returnedCalendar = runFlowAndGetPayload("get-calendar-by-id");
-			assertTrue(returnedCalendar != null);
-			assertTrue(returnedCalendar.getId().equals(createdCalendar.getId()));
-		}
-		catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
+            assertTrue(createdCalendar != null);
+            assertTrue(createdCalendar.getSummary().equals(originalCalendar.getSummary()));
 
-		runFlowAndGetPayload("delete-calendar");
+            upsertOnTestRunMessage("id", createdCalendar.getId());
 
-	}
-	
+            Calendar returnedCalendar = runFlowAndGetPayload("get-calendar-by-id");
+            assertTrue(returnedCalendar != null);
+            assertTrue(returnedCalendar.getId().equals(createdCalendar.getId()));
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        runFlowAndGetPayload("delete-calendar");
+
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteAclRuleTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteAclRuleTestCases.java
@@ -28,19 +28,11 @@ public class DeleteAclRuleTestCases extends GoogleCalendarTestParent {
 
         initializeTestRunMessage("deleteAclRule");
 
-        // Insert calendar and get reference to retrieved calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Replace old calendar instance with new instance
-        upsertOnTestRunMessage("calendarRef", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
-
         // Insert the ACL rule
         AclRule aclRule = runFlowAndGetPayload("insert-acl-rule");
 
         upsertOnTestRunMessage("aclRule", aclRule);
         upsertOnTestRunMessage("ruleId", aclRule.getId());
-
     }
 
     @Category({SmokeTests.class, RegressionTests.class})
@@ -60,13 +52,4 @@ public class DeleteAclRuleTestCases extends GoogleCalendarTestParent {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
     }
-
-    @After
-    public void tearDown() throws Exception {
-
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
-
-    }
-
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteAclRuleTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteAclRuleTestCases.java
@@ -10,71 +10,63 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.AclRule;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.*;
 
 public class DeleteAclRuleTestCases extends GoogleCalendarTestParent {
-	
-	@Before
-	public void setUp() throws Exception {
 
-			loadTestRunMessage("deleteAclRule");
-			
-			// Insert calendar and get reference to retrieved calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Replace old calendar instance with new instance
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-			
-			// Insert the ACL rule
-			AclRule aclRule = runFlowAndGetPayload("insert-acl-rule");
-						
-			upsertOnTestRunMessage("aclRule", aclRule);	
-			upsertOnTestRunMessage("ruleId", aclRule.getId());
+    @Before
+    public void setUp() throws Exception {
 
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testDeleteAclRule() {
-		try {
-			
-			runFlowAndGetPayload("delete-acl-rule");
-			AclRule afterDel = runFlowAndGetPayload("get-acl-rule-by-id");
-			String ruleIdAfter = afterDel.getId();
-			
-			assertEquals(getTestRunMessageValue("ruleId").toString(),ruleIdAfter);
-			assertFalse(EqualsBuilder.reflectionEquals(getTestRunMessageValue("aclRule"), afterDel));
-			assertTrue(afterDel.getRole().equals("none"));
-				
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
+        initializeTestRunMessage("deleteAclRule");
 
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
+        // Insert calendar and get reference to retrieved calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
 
-	}
+        // Replace old calendar instance with new instance
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+        // Insert the ACL rule
+        AclRule aclRule = runFlowAndGetPayload("insert-acl-rule");
+
+        upsertOnTestRunMessage("aclRule", aclRule);
+        upsertOnTestRunMessage("ruleId", aclRule.getId());
+
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testDeleteAclRule() {
+        try {
+
+            runFlowAndGetPayload("delete-acl-rule");
+            AclRule afterDel = runFlowAndGetPayload("get-acl-rule-by-id");
+            String ruleIdAfter = afterDel.getId();
+
+            assertEquals(getTestRunMessageValue("ruleId").toString(), ruleIdAfter);
+            assertFalse(EqualsBuilder.reflectionEquals(getTestRunMessageValue("aclRule"), afterDel));
+            assertTrue(afterDel.getRole().equals("none"));
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteCalendarListTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteCalendarListTestCases.java
@@ -32,7 +32,7 @@ public class DeleteCalendarListTestCases extends GoogleCalendarTestParent {
             Calendar calendar = runFlowAndGetPayload("create-calendar");
 
             upsertOnTestRunMessage("calendar", calendar);
-            upsertOnTestRunMessage("id", calendar.getId());
+            upsertOnTestRunMessage("calendarId", calendar.getId());
 
             //Get Calendar List
             CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
@@ -71,9 +71,7 @@ public class DeleteCalendarListTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        String calendarId = getTestRunMessageValue("id");
-        deleteCalendar(calendarId);
-
+        runFlowAndGetPayload("delete-calendar");
     }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteCalendarListTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteCalendarListTestCases.java
@@ -10,80 +10,70 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class DeleteCalendarListTestCases extends GoogleCalendarTestParent{
-	
-	
-	@Before
-	public void setUp() throws Exception {
-		try {
-			loadTestRunMessage("deleteCalendarList");
-	
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-						
-			upsertOnTestRunMessage("calendar", calendar);
-			upsertOnTestRunMessage("id", calendar.getId());
-			
-			//Get Calendar List 
-			CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
-			
-			upsertOnTestRunMessage("calendarList", returnedCalendarList);
-			upsertOnTestRunMessage("color", returnedCalendarList.getColorId());
+public class DeleteCalendarListTestCases extends GoogleCalendarTestParent {
 
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail();
-		}
-	}
-	
-	
-	@Category({RegressionTests.class})
-	@Test
-	public void testDeleteCalendarList() {
-		try {
-			runFlowAndGetPayload("delete-calendar-list");
-		}
-		catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-				
-		// Get the calendar list, should throw an exception
-		try {
-			runFlowAndGetPayload("get-calendar-list-by-id");
-		}
-		catch (Exception e) {
-			if (e.getCause() instanceof GoogleJsonResponseException) {
-				GoogleJsonResponseException googleException = (GoogleJsonResponseException) e.getCause();
-				 // Not found
-				assertTrue(googleException.getStatusCode() == 404);
-				assertTrue(googleException.getStatusMessage().equals("Not Found"));
-			}
-			else fail();
-		}
-	}
-		
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("id");
-			deleteCalendar(calendarId);
+    @Before
+    public void setUp() throws Exception {
+        try {
+            initializeTestRunMessage("deleteCalendarList");
 
-	}
+            Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+            upsertOnTestRunMessage("calendar", calendar);
+            upsertOnTestRunMessage("id", calendar.getId());
+
+            //Get Calendar List
+            CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
+
+            upsertOnTestRunMessage("calendarList", returnedCalendarList);
+            upsertOnTestRunMessage("color", returnedCalendarList.getColorId());
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testDeleteCalendarList() {
+        try {
+            runFlowAndGetPayload("delete-calendar-list");
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+
+        // Get the calendar list, should throw an exception
+        try {
+            runFlowAndGetPayload("get-calendar-list-by-id");
+        } catch (Exception e) {
+            if (e.getCause() instanceof GoogleJsonResponseException) {
+                GoogleJsonResponseException googleException = (GoogleJsonResponseException) e.getCause();
+                // Not found
+                assertTrue(googleException.getStatusCode() == 404);
+                assertTrue(googleException.getStatusMessage().equals("Not Found"));
+            } else fail(ConnectorTestUtils.getStackTrace(e));
+            ;
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("id");
+        deleteCalendar(calendarId);
+
+    }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteCalendarTestCases.java
@@ -10,60 +10,52 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class DeleteCalendarTestCases extends GoogleCalendarTestParent {
 
-	@SuppressWarnings("unchecked")
-	@Before
-	public void setUp() throws Exception {
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
 
-			loadTestRunMessage("deleteCalendar");
+        initializeTestRunMessage("deleteCalendar");
 
-			// Create the calendar)
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			upsertOnTestRunMessage("id", calendar.getId());
+        // Create the calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+        upsertOnTestRunMessage("id", calendar.getId());
 
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testDeleteCalendar() {
-		try {
-			// Delete the calendar
-			runFlowAndGetPayload("delete-calendar");
+    }
 
-		}
-		catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-			
-		// Get the calendar, should throw an exception
-		try {		
-			runFlowAndGetPayload("get-calendar-by-id");
-		}
-		catch (Exception e) {
-			if (e.getCause() instanceof GoogleJsonResponseException) {
-				GoogleJsonResponseException googleException = (GoogleJsonResponseException) e.getCause();
-				 // Not found
-				assertTrue(googleException.getStatusCode() == 404);
-				assertTrue(googleException.getStatusMessage().equals("Not Found"));
-			}
-			else fail();
-		}
-	}
-	
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testDeleteCalendar() {
+        try {
+            // Delete the calendar
+            runFlowAndGetPayload("delete-calendar");
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+
+        // Get the calendar, should throw an exception
+        try {
+            runFlowAndGetPayload("get-calendar-by-id");
+        } catch (Exception e) {
+            if (e.getCause() instanceof GoogleJsonResponseException) {
+                GoogleJsonResponseException googleException = (GoogleJsonResponseException) e.getCause();
+                // Not found
+                assertTrue(googleException.getStatusCode() == 404);
+                assertTrue(googleException.getStatusMessage().equals("Not Found"));
+            } else fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteCalendarTestCases.java
@@ -30,7 +30,7 @@ public class DeleteCalendarTestCases extends GoogleCalendarTestParent {
 
         // Create the calendar
         Calendar calendar = runFlowAndGetPayload("create-calendar");
-        upsertOnTestRunMessage("id", calendar.getId());
+        upsertOnTestRunMessage("calendarId", calendar.getId());
 
     }
 

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteEventTestCases.java
@@ -10,11 +10,9 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
@@ -27,13 +25,6 @@ public class DeleteEventTestCases extends GoogleCalendarTestParent {
     public void setUp() throws Exception {
 
         initializeTestRunMessage("deleteEvent");
-
-        // Insert calendar and get reference to retrieved calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Replace old calendar instance with new instance
-        upsertOnTestRunMessage("calendarRef", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
 
         // Place the returned event and its ID into testObjects for later access
         Event returnedEvent = runFlowAndGetPayload("insert-event");
@@ -55,13 +46,5 @@ public class DeleteEventTestCases extends GoogleCalendarTestParent {
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
-    }
-
-    @After
-    public void tearDown() throws Exception {
-
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
-
     }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/DeleteEventTestCases.java
@@ -10,64 +10,58 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class DeleteEventTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
 
-		loadTestRunMessage("deleteEvent");
-		
-		// Insert calendar and get reference to retrieved calendar
-		Calendar calendar = runFlowAndGetPayload("create-calendar");
-		
-		// Replace old calendar instance with new instance
-		upsertOnTestRunMessage("calendarRef", calendar);
-		upsertOnTestRunMessage("calendarId", calendar.getId());
+        initializeTestRunMessage("deleteEvent");
 
-		// Place the returned event and its ID into testObjects for later access
-		Event returnedEvent = runFlowAndGetPayload("insert-event");
-		upsertOnTestRunMessage("event", returnedEvent);
-		upsertOnTestRunMessage("eventId", returnedEvent.getId());
+        // Insert calendar and get reference to retrieved calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
 
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})	
-	@Test
-	public void testDeleteEvent() {
-		try {			
-			// Delete the event
-			runFlowAndGetPayload("delete-event");
-			// Try and look for the event after cancelling it	
-			Event returnedEvent = runFlowAndGetPayload("get-event-by-id");
-			assertTrue(returnedEvent.getStatus().equals("cancelled"));
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
+        // Replace old calendar instance with new instance
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
 
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
+        // Place the returned event and its ID into testObjects for later access
+        Event returnedEvent = runFlowAndGetPayload("insert-event");
+        upsertOnTestRunMessage("event", returnedEvent);
+        upsertOnTestRunMessage("eventId", returnedEvent.getId());
 
-	}
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testDeleteEvent() {
+        try {
+            // Delete the event
+            runFlowAndGetPayload("delete-event");
+            // Try and look for the event after cancelling it
+            Event returnedEvent = runFlowAndGetPayload("get-event-by-id");
+            assertTrue(returnedEvent.getStatus().equals("cancelled"));
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetAclRuleByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetAclRuleByIdTestCases.java
@@ -15,7 +15,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mule.module.google.calendar.model.AclRule;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
 import static org.junit.Assert.assertEquals;
@@ -28,13 +27,6 @@ public class GetAclRuleByIdTestCases extends GoogleCalendarTestParent {
     public void setUp() throws Exception {
 
         initializeTestRunMessage("getAclRuleById");
-
-        // Insert calendar and get reference to retrieved calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Replace old calendar instance with new instance
-        upsertOnTestRunMessage("calendarRef", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
 
         // Insert the ACL rule
         AclRule returnedAclRule = runFlowAndGetPayload("insert-acl-rule");
@@ -62,10 +54,7 @@ public class GetAclRuleByIdTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
-
+        runFlowAndGetPayload("delete-acl-rule");
     }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetAclRuleByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetAclRuleByIdTestCases.java
@@ -10,67 +10,62 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.AclRule;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class GetAclRuleByIdTestCases extends GoogleCalendarTestParent {
-	
-	
-	@Before
-	public void setUp() throws Exception {
 
-			loadTestRunMessage("getAclRuleById");
-			
-			// Insert calendar and get reference to retrieved calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Replace old calendar instance with new instance
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-			
-			// Insert the ACL rule				
-			AclRule returnedAclRule = runFlowAndGetPayload("insert-acl-rule");
-			upsertOnTestRunMessage("aclRule", returnedAclRule);	
-			upsertOnTestRunMessage("ruleId", returnedAclRule.getId());
-			
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})	
-	@Test
-	public void testGetAclRuleById() {
-		try {
-			String ruleIdBefore = getTestRunMessageValue("ruleId");
 
-			AclRule afterProc = runFlowAndGetPayload("get-acl-rule-by-id");
-			String ruleIdAfter = afterProc.getId();
-			
-			assertEquals(ruleIdBefore,ruleIdAfter);		
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	
-	@After
-	public void tearDown() throws Exception {
+    @Before
+    public void setUp() throws Exception {
 
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
+        initializeTestRunMessage("getAclRuleById");
 
-	}
+        // Insert calendar and get reference to retrieved calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+        // Replace old calendar instance with new instance
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+        // Insert the ACL rule
+        AclRule returnedAclRule = runFlowAndGetPayload("insert-acl-rule");
+        upsertOnTestRunMessage("aclRule", returnedAclRule);
+        upsertOnTestRunMessage("ruleId", returnedAclRule.getId());
+
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testGetAclRuleById() {
+        try {
+            String ruleIdBefore = getTestRunMessageValue("ruleId");
+
+            AclRule afterProc = runFlowAndGetPayload("get-acl-rule-by-id");
+            String ruleIdAfter = afterProc.getId();
+
+            assertEquals(ruleIdBefore, ruleIdAfter);
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetAllAclRulesTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetAllAclRulesTestCases.java
@@ -10,73 +10,69 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.automation.CalendarUtils;
 import org.mule.module.google.calendar.model.AclRule;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class GetAllAclRulesTestCases extends GoogleCalendarTestParent {
 
-	protected List<AclRule> insertedAclRules = new ArrayList<AclRule>();
-		
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("getAllAclRules");
-			
-			// Insert calendar and get reference to retrieved calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Replace old calendar instance with new instance
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
+    protected List<AclRule> insertedAclRules = new ArrayList<AclRule>();
 
-			
-			List<String> scopes = (List<String>) getTestRunMessageValue("scopes");
-			
-			// Insert the different scopes
-			for (String scope : scopes) {
-				upsertOnTestRunMessage("scope", scope);	
-				AclRule aclRule = runFlowAndGetPayload("insert-acl-rule");
-				insertedAclRules.add(aclRule);
-			}
-				
-	}
-	
-	@Category({RegressionTests.class})
-	@Test
-	public void testGetAllAclRules() {
-		try {
-			
-			List<AclRule> aclRuleList = runFlowAndGetPayload("get-all-acl-rules");
-			
-			for (AclRule insertedAclRule : insertedAclRules) {
-				assertTrue(CalendarUtils.isAclRuleInList(aclRuleList, insertedAclRule));
-			}
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}	
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("getAllAclRules");
 
-	}
+        // Insert calendar and get reference to retrieved calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
 
-	
+        // Replace old calendar instance with new instance
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+
+        List<String> scopes = (List<String>) getTestRunMessageValue("scopes");
+
+        // Insert the different scopes
+        for (String scope : scopes) {
+            upsertOnTestRunMessage("scope", scope);
+            AclRule aclRule = runFlowAndGetPayload("insert-acl-rule");
+            insertedAclRules.add(aclRule);
+        }
+
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testGetAllAclRules() {
+        try {
+
+            List<AclRule> aclRuleList = runFlowAndGetPayload("get-all-acl-rules");
+
+            for (AclRule insertedAclRule : insertedAclRules) {
+                assertTrue(CalendarUtils.isAclRuleInList(aclRuleList, insertedAclRule));
+            }
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetAllAclRulesTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetAllAclRulesTestCases.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mule.module.google.calendar.automation.CalendarUtils;
 import org.mule.module.google.calendar.model.AclRule;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
 import java.util.ArrayList;
@@ -32,14 +31,6 @@ public class GetAllAclRulesTestCases extends GoogleCalendarTestParent {
     @Before
     public void setUp() throws Exception {
         initializeTestRunMessage("getAllAclRules");
-
-        // Insert calendar and get reference to retrieved calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Replace old calendar instance with new instance
-        upsertOnTestRunMessage("calendarRef", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
-
 
         List<String> scopes = (List<String>) getTestRunMessageValue("scopes");
 
@@ -70,9 +61,9 @@ public class GetAllAclRulesTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
-
+        for (AclRule aclRule : insertedAclRules) {
+            upsertOnTestRunMessage("ruleId", aclRule.getId());
+            runFlowAndGetPayload("delete-acl-rule");
+        }
     }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarByIdTestCases.java
@@ -10,55 +10,51 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class GetCalendarByIdTestCases extends GoogleCalendarTestParent {
 
-	@SuppressWarnings("unchecked")
-	@Before
-	public void setUp() throws Exception {
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
 
-			loadTestRunMessage("getCalendarById");
+        initializeTestRunMessage("getCalendarById");
 
-			// Create the calendar		
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			upsertOnTestRunMessage("id", calendar.getId());
+        // Create the calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+        upsertOnTestRunMessage("id", calendar.getId());
 
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testGetCalendarById() {
-		try {
-			
-			String createdCalendarId = getTestRunMessageValue("id");
+    }
 
-			// Assertions on equality
-			Calendar returnedCalendar = runFlowAndGetPayload("get-calendar-by-id");
-			assertTrue(returnedCalendar != null);
-			assertTrue(returnedCalendar.getId().equals(createdCalendarId));
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			// Delete the calendar
-			runFlowAndGetPayload("delete-calendar");
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testGetCalendarById() {
+        try {
 
-	}
+            String createdCalendarId = getTestRunMessageValue("id");
+
+            // Assertions on equality
+            Calendar returnedCalendar = runFlowAndGetPayload("get-calendar-by-id");
+            assertTrue(returnedCalendar != null);
+            assertTrue(returnedCalendar.getId().equals(createdCalendarId));
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Delete the calendar
+        runFlowAndGetPayload("delete-calendar");
+
+    }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarByIdTestCases.java
@@ -10,7 +10,6 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -27,34 +26,17 @@ public class GetCalendarByIdTestCases extends GoogleCalendarTestParent {
     public void setUp() throws Exception {
 
         initializeTestRunMessage("getCalendarById");
-
-        // Create the calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-        upsertOnTestRunMessage("id", calendar.getId());
-
     }
 
     @Category({SmokeTests.class, RegressionTests.class})
     @Test
     public void testGetCalendarById() {
         try {
-
-            String createdCalendarId = getTestRunMessageValue("id");
-
             // Assertions on equality
             Calendar returnedCalendar = runFlowAndGetPayload("get-calendar-by-id");
             assertTrue(returnedCalendar != null);
-            assertTrue(returnedCalendar.getId().equals(createdCalendarId));
-
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        // Delete the calendar
-        runFlowAndGetPayload("delete-calendar");
-
     }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListByIdTestCases.java
@@ -33,7 +33,7 @@ public class GetCalendarListByIdTestCases extends GoogleCalendarTestParent {
             CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
 
             assertTrue(returnedCalendarList != null);
-            assertTrue(returnedCalendarList.getPrimary());
+            assertTrue(returnedCalendarList.isPrimary());
 
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListByIdTestCases.java
@@ -10,55 +10,33 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class GetCalendarListByIdTestCases extends GoogleCalendarTestParent {
 
     @Before
     public void setUp() throws Exception {
-
         initializeTestRunMessage("getCalendarListById");
-
-        // Create the calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-        upsertOnTestRunMessage("calendar", calendar);
-        upsertOnTestRunMessage("id", calendar.getId());
-
     }
 
     @Category({SmokeTests.class, RegressionTests.class})
     @Test
     public void testGetCalendarListById() {
         try {
-
-            Calendar originalCalendar = getTestRunMessageValue("calendar");
-
-            String createdCalendarId = getTestRunMessageValue("id");
-
             CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
 
             assertTrue(returnedCalendarList != null);
-            assertTrue(returnedCalendarList.getId().equals(createdCalendarId));
-            assertEquals(returnedCalendarList.getSummary(), originalCalendar.getSummary());
+            assertTrue(returnedCalendarList.getPrimary());
 
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
     }
-
-    @After
-    public void tearDown() throws Exception {
-        // Delete the calendar
-        runFlowAndGetPayload("delete-calendar");
-
-    }
-
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListByIdTestCases.java
@@ -10,61 +10,55 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-public class GetCalendarListByIdTestCases extends GoogleCalendarTestParent{
+import static org.junit.Assert.*;
 
-	@Before
-	public void setUp() throws Exception {
+public class GetCalendarListByIdTestCases extends GoogleCalendarTestParent {
 
-			loadTestRunMessage("getCalendarListById");
+    @Before
+    public void setUp() throws Exception {
 
-			// Create the calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			upsertOnTestRunMessage("calendar",calendar);
-			upsertOnTestRunMessage("id", calendar.getId());
+        initializeTestRunMessage("getCalendarListById");
 
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testGetCalendarListById() {
-		try {
-			
-			Calendar originalCalendar = getTestRunMessageValue("calendar");
-			
-			String createdCalendarId = getTestRunMessageValue("id");
+        // Create the calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+        upsertOnTestRunMessage("calendar", calendar);
+        upsertOnTestRunMessage("id", calendar.getId());
 
-			CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
+    }
 
-			assertTrue(returnedCalendarList != null);
-			assertTrue(returnedCalendarList.getId().equals(createdCalendarId));
-			assertEquals(returnedCalendarList.getSummary(), originalCalendar.getSummary());
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			// Delete the calendar
-			runFlowAndGetPayload("delete-calendar");
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testGetCalendarListById() {
+        try {
 
-	}
-	
+            Calendar originalCalendar = getTestRunMessageValue("calendar");
+
+            String createdCalendarId = getTestRunMessageValue("id");
+
+            CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
+
+            assertTrue(returnedCalendarList != null);
+            assertTrue(returnedCalendarList.getId().equals(createdCalendarId));
+            assertEquals(returnedCalendarList.getSummary(), originalCalendar.getSummary());
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Delete the calendar
+        runFlowAndGetPayload("delete-calendar");
+
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListTestCases.java
@@ -10,74 +10,71 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.automation.CalendarUtils;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
+import org.mule.streaming.ConsumerIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class GetCalendarListTestCases extends GoogleCalendarTestParent {
 
-	protected List<Calendar> insertedCalendars = new ArrayList<Calendar>();
-	
-	@SuppressWarnings("unchecked")
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("getCalendarList");
-			
-			Integer numCalendars = getTestRunMessageValue("numCalendars");
-			
-			// Create calendar instances
-			List<Calendar> calendars = new ArrayList<Calendar>();
-			for (int i = 0; i < numCalendars; i++) {
-				calendars.add(CalendarUtils.getCalendar("This is a title"));
-			}
+    protected List<Calendar> insertedCalendars = new ArrayList<Calendar>();
 
-			// Insert calendars and record their IDs
-			BatchResponse<Calendar> response = insertCalendars(calendars);	
-			
-			for (Calendar calendar : response.getSuccessful()) {
-				insertedCalendars.add(calendar);
-			}					
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("getCalendarList");
 
-	}
-	
-	@Ignore("Needs to be review")
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testGetCalendarList() {
-		try {
-			
-			List<CalendarList> calendarList = runFlowAndGetPayload("get-calendar-list");
-			
-			for (Calendar insertedCalendar : insertedCalendars) {
-				assertTrue(CalendarUtils.isCalendarInList(calendarList, insertedCalendar));
-			}
-			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
+        Integer numCalendars = getTestRunMessageValue("numCalendars");
 
-			// Delete the calendars
-			deleteCalendars(insertedCalendars);			
+        // Create calendar instances
+        List<Calendar> calendars = new ArrayList<Calendar>();
+        for (int i = 0; i < numCalendars; i++) {
+            calendars.add(CalendarUtils.getCalendar("This is a title"));
+        }
 
-	}
+        // Insert calendars and record their IDs
+        BatchResponse<Calendar> response = insertCalendars(calendars);
+
+        for (Calendar calendar : response.getSuccessful()) {
+            insertedCalendars.add(calendar);
+        }
+
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testGetCalendarList() {
+        try {
+
+            ConsumerIterator<CalendarList> consumerIterator = runFlowAndGetPayload("get-calendar-list");
+            List<CalendarList> calendarList = Lists.newArrayList(consumerIterator);
+            for (Calendar insertedCalendar : insertedCalendars) {
+                assertTrue(CalendarUtils.isCalendarInList(calendarList, insertedCalendar));
+            }
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        // Delete the calendars
+        deleteCalendars(insertedCalendars);
+
+    }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetCalendarListTestCases.java
@@ -10,71 +10,31 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import com.google.common.collect.Lists;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.module.google.calendar.automation.CalendarUtils;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
-import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
-import org.mule.streaming.ConsumerIterator;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Iterator;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class GetCalendarListTestCases extends GoogleCalendarTestParent {
 
-    protected List<Calendar> insertedCalendars = new ArrayList<Calendar>();
-
-    @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() throws Exception {
-        initializeTestRunMessage("getCalendarList");
-
-        Integer numCalendars = getTestRunMessageValue("numCalendars");
-
-        // Create calendar instances
-        List<Calendar> calendars = new ArrayList<Calendar>();
-        for (int i = 0; i < numCalendars; i++) {
-            calendars.add(CalendarUtils.getCalendar("This is a title"));
-        }
-
-        // Insert calendars and record their IDs
-        BatchResponse<Calendar> response = insertCalendars(calendars);
-
-        for (Calendar calendar : response.getSuccessful()) {
-            insertedCalendars.add(calendar);
-        }
-
-    }
-
     @Category({SmokeTests.class, RegressionTests.class})
     @Test
     public void testGetCalendarList() {
         try {
+            // get-calendar-list returns a ConsumerIterator that can only be consumed as an iterator
+            // Therefore, if the iterator has any element, it means that at least one calendar has been fetched.
+            Iterator<CalendarList> returnedCalendars = runFlowAndGetPayload("get-calendar-list");
 
-            ConsumerIterator<CalendarList> consumerIterator = runFlowAndGetPayload("get-calendar-list");
-            List<CalendarList> calendarList = Lists.newArrayList(consumerIterator);
-            for (Calendar insertedCalendar : insertedCalendars) {
-                assertTrue(CalendarUtils.isCalendarInList(calendarList, insertedCalendar));
-            }
+            // Assert that atleast one (expected default primary) calendar is returned
+            assertTrue(returnedCalendars.hasNext());
 
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
-    }
-
-    @After
-    public void tearDown() throws Exception {
-
-        // Delete the calendars
-        deleteCalendars(insertedCalendars);
-
     }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetEventByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetEventByIdTestCases.java
@@ -14,7 +14,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
@@ -25,23 +24,12 @@ public class GetEventByIdTestCases extends GoogleCalendarTestParent {
 
     @Before
     public void setUp() throws Exception {
-        try {
-            initializeTestRunMessage("getEventById");
+        initializeTestRunMessage("getEventById");
 
-            // Insert calendar and get reference to retrieved calendar
-            Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-            // Replace old calendar instance with new instance
-            upsertOnTestRunMessage("calendarRef", calendar);
-            upsertOnTestRunMessage("calendarId", calendar.getId());
-
-            // Place the returned event and its ID into testObjects for later access
-            Event returnedEvent = runFlowAndGetPayload("insert-event");
-            upsertOnTestRunMessage("event", returnedEvent);
-            upsertOnTestRunMessage("eventId", returnedEvent.getId());
-        } catch (Exception e) {
-            fail(ConnectorTestUtils.getStackTrace(e));
-        }
+        // Place the returned event and its ID into testObjects for later access
+        Event returnedEvent = runFlowAndGetPayload("insert-event");
+        upsertOnTestRunMessage("event", returnedEvent);
+        upsertOnTestRunMessage("eventId", returnedEvent.getId());
     }
 
     @Category({SmokeTests.class, RegressionTests.class})
@@ -60,7 +48,6 @@ public class GetEventByIdTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
+       runFlowAndGetPayload("delete-event");
     }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetEventByIdTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetEventByIdTestCases.java
@@ -10,67 +10,57 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class GetEventByIdTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-		try {
-			loadTestRunMessage("getEventById");
-			
-			// Insert calendar and get reference to retrieved calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Replace old calendar instance with new instance
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-			
-			// Place the returned event and its ID into testObjects for later access
-			Event returnedEvent = runFlowAndGetPayload("insert-event");
-			upsertOnTestRunMessage("event", returnedEvent);
-			upsertOnTestRunMessage("eventId", returnedEvent.getId());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail();
-		}
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})	
-	@Test
-	public void testGetEventById() {
-		try {
-			Event originalEvent = getTestRunMessageValue("event");
-			// No exceptions thrown means that the event was found
-			// Perform assertions. Check that the returned event has the same id
-			Event returnedEvent = runFlowAndGetPayload("get-event-by-id");
-			assertTrue(returnedEvent.getId().equals(originalEvent.getId()));		
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
+    @Before
+    public void setUp() throws Exception {
+        try {
+            initializeTestRunMessage("getEventById");
 
-	}
-	
-	
+            // Insert calendar and get reference to retrieved calendar
+            Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+            // Replace old calendar instance with new instance
+            upsertOnTestRunMessage("calendarRef", calendar);
+            upsertOnTestRunMessage("calendarId", calendar.getId());
+
+            // Place the returned event and its ID into testObjects for later access
+            Event returnedEvent = runFlowAndGetPayload("insert-event");
+            upsertOnTestRunMessage("event", returnedEvent);
+            upsertOnTestRunMessage("eventId", returnedEvent.getId());
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testGetEventById() {
+        try {
+            Event originalEvent = getTestRunMessageValue("event");
+            // No exceptions thrown means that the event was found
+            // Perform assertions. Check that the returned event has the same id
+            Event returnedEvent = runFlowAndGetPayload("get-event-by-id");
+            assertTrue(returnedEvent.getId().equals(originalEvent.getId()));
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+    }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetEventsTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetEventsTestCases.java
@@ -10,153 +10,148 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Lists;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.automation.CalendarUtils;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.module.google.calendar.model.EventDateTime;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestUtils;
+import org.mule.streaming.ConsumerIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class GetEventsTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
 
-			loadTestRunMessage("getEvents");
-			
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			upsertOnTestRunMessage("calendar", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
+        initializeTestRunMessage("getEvents");
 
-			// Get the sample event
-			Event sampleEvent = getTestRunMessageValue("sampleEvent");
-			
-			// Get start and end time beans.
-			String eventTitle = sampleEvent.getSummary();
-			EventDateTime eventStartTime = sampleEvent.getStart();
-			EventDateTime eventEndTime = sampleEvent.getEnd();
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
 
-			Integer numEvents = getTestRunMessageValue("numEvents");
-			
-			// Create the test events
-			List<Event> events = new ArrayList<Event>();			
-			for (int i = 0; i < numEvents; i++) {
-				Event event = CalendarUtils.getEvent(eventTitle, eventStartTime, eventEndTime);
-				events.add(event);
-			}
-			
-			// Batch insert the events and store successfully created events in testObjects
-			BatchResponse<Event> returnedEvents = insertEvents(calendar, events);
-			
-			upsertOnTestRunMessage("events", returnedEvents.getSuccessful());
+        upsertOnTestRunMessage("calendar", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
 
-	}
+        // Get the sample event
+        Event sampleEvent = getTestRunMessageValue("sampleEvent");
 
-	@Ignore("Needs to be review")
-	@SuppressWarnings("unchecked")
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testGetEvents_AllEvents() {
-		try {
-			List<Event> insertedEvents = (List<Event>) getTestRunMessageValue("events");
-						
-			// Get the events		
-			List<Event> returnedEvents = runFlowAndGetPayload("get-all-events");
-			
-			// Perform assertions on the list
-			boolean listsSame = EqualsBuilder.reflectionEquals(insertedEvents, returnedEvents);
-			assertTrue(listsSame);
-			for (Event event : insertedEvents) {
-				assertTrue(CalendarUtils.isEventInList(returnedEvents, event));
-			}			
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
+        // Get start and end time beans.
+        String eventTitle = sampleEvent.getSummary();
+        EventDateTime eventStartTime = sampleEvent.getStart();
+        EventDateTime eventEndTime = sampleEvent.getEnd();
 
-	@Ignore("Needs to be review")
-	@SuppressWarnings("unchecked")
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testGetEvents_ShowDeleted() {
-		try {
+        Integer numEvents = getTestRunMessageValue("numEvents");
 
-			// We do not want any limit on the number of results we receive
-			upsertOnTestRunMessage("maxResults", Integer.MAX_VALUE);
-			// We want to be able to retrieve deleted events
-			upsertOnTestRunMessage("showDeleted", true);
-			
-			String calendarId = getTestRunMessageValue("calendarId");
-			
-			// Delete all events which we created in the setUp() method
-			List<Event> events = (List<Event>) getTestRunMessageValue("events");
-			deleteEvents(calendarId, events);
-						
-			// Get the events			
-			List<Event> returnedEvents = runFlowAndGetPayload("get-events");
-			
-			// Perform assertions on the list
-			// Every event that was inserted should have been retrieved
-			assertTrue(returnedEvents.size() == events.size());
-			// Every event in the list should have been deleted, so check that the status is so
-			for (Event event : returnedEvents) {
-				assertTrue(event.getStatus().equals("cancelled"));	
-				assertTrue(CalendarUtils.isEventInList(events, event));
-			}
+        // Create the test events
+        List<Event> events = new ArrayList<Event>();
+        for (int i = 0; i < numEvents; i++) {
+            Event event = CalendarUtils.getEvent(eventTitle, eventStartTime, eventEndTime);
+            events.add(event);
+        }
 
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@Ignore("Needs to be review")
-	@SuppressWarnings("unchecked")
-	@Category({SmokeTests.class, RegressionTests.class})
-	@Test
-	public void testGetEvents_UsingQuery() {
-		try {
-			
-			Event sampleEvent = getTestRunMessageValue("sampleEvent");
-			String eventTitle = sampleEvent.getSummary();
-			List<Event> insertedEvents = (List<Event>) getTestRunMessageValue("events");
-			
-			// Get the events		
-			List<Event> returnedEvents = runFlowAndGetPayload("get-events-using-query");
-			
-			// Since the query is a substring of the events' names, every created event should have been retrieved
-			// Assert list sizes, assert returned event titles, and assert total equality on the inserted list of events and the retrieved list of events
-			assertTrue(returnedEvents.size() == insertedEvents.size());
-			for (Event event : returnedEvents) {
-				assertTrue(event.getSummary().equals(eventTitle));
-			}
-			boolean listsSame = EqualsBuilder.reflectionEquals(insertedEvents, returnedEvents);
-			assertTrue(listsSame);
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			Calendar calendar = getTestRunMessageValue("calendar");
-			deleteCalendar(calendar);
+        // Batch insert the events and store successfully created events in testObjects
+        BatchResponse<Event> returnedEvents = insertEvents(calendar, events);
 
-	}
-	
+        upsertOnTestRunMessage("events", returnedEvents.getSuccessful());
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testGetEvents_AllEvents() {
+        try {
+            List<Event> insertedEvents = (List<Event>) getTestRunMessageValue("events");
+
+            // Get the events
+            ConsumerIterator<Event> consumerIterator = runFlowAndGetPayload("get-all-events");
+            List<Event> returnedEvents = Lists.newArrayList(consumerIterator);
+            // Perform assertions on the list
+            boolean listsSame = EqualsBuilder.reflectionEquals(insertedEvents, returnedEvents);
+            assertTrue(listsSame);
+            for (Event event : insertedEvents) {
+                assertTrue(CalendarUtils.isEventInList(returnedEvents, event));
+            }
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testGetEvents_ShowDeleted() {
+        try {
+
+            // We do not want any limit on the number of results we receive
+            upsertOnTestRunMessage("maxResults", Integer.MAX_VALUE);
+            // We want to be able to retrieve deleted events
+            upsertOnTestRunMessage("showDeleted", true);
+
+            String calendarId = getTestRunMessageValue("calendarId");
+
+            // Delete all events which we created in the setUp() method
+            List<Event> events = (List<Event>) getTestRunMessageValue("events");
+            deleteEvents(calendarId, events);
+
+            // Get the events
+            ConsumerIterator<Event> consumerIterator = runFlowAndGetPayload("get-events");
+            List<Event> returnedEvents = Lists.newArrayList(consumerIterator);
+            // Perform assertions on the list
+            // Every event that was inserted should have been retrieved
+            assertTrue(returnedEvents.size() == events.size());
+            // Every event in the list should have been deleted, so check that the status is so
+            for (Event event : returnedEvents) {
+                assertTrue(event.getStatus().equals("cancelled"));
+                assertTrue(CalendarUtils.isEventInList(events, event));
+            }
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testGetEvents_UsingQuery() {
+        try {
+
+            Event sampleEvent = getTestRunMessageValue("sampleEvent");
+            String eventTitle = sampleEvent.getSummary();
+            List<Event> insertedEvents = (List<Event>) getTestRunMessageValue("events");
+
+            // Get the events
+            ConsumerIterator<Event> consumerIterator = runFlowAndGetPayload("get-events-using-query");
+            List<Event> returnedEvents = Lists.newArrayList(consumerIterator);
+            // Since the query is a substring of the events' names, every created event should have been retrieved
+            // Assert list sizes, assert returned event titles, and assert total equality on the inserted list of events and the retrieved list of events
+            assertTrue(returnedEvents.size() == insertedEvents.size());
+            for (Event event : returnedEvents) {
+                assertTrue(event.getSummary().equals(eventTitle));
+            }
+            boolean listsSame = EqualsBuilder.reflectionEquals(insertedEvents, returnedEvents);
+            assertTrue(listsSame);
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Calendar calendar = getTestRunMessageValue("calendar");
+        deleteCalendar(calendar);
+
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetEventsTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetEventsTestCases.java
@@ -60,7 +60,7 @@ public class GetEventsTestCases extends GoogleCalendarTestParent {
         }
 
         // Batch insert the events and store successfully created events in testObjects
-        BatchResponse<Event> returnedEvents = insertEvents(calendar, events);
+        BatchResponse<Event> returnedEvents = insertEvents(events);
 
         upsertOnTestRunMessage("events", returnedEvents.getSuccessful());
 
@@ -98,11 +98,9 @@ public class GetEventsTestCases extends GoogleCalendarTestParent {
             // We want to be able to retrieve deleted events
             upsertOnTestRunMessage("showDeleted", true);
 
-            String calendarId = getTestRunMessageValue("calendarId");
-
             // Delete all events which we created in the setUp() method
             List<Event> events = (List<Event>) getTestRunMessageValue("events");
-            deleteEvents(calendarId, events);
+            deleteEvents(events);
 
             // Get the events
             ConsumerIterator<Event> consumerIterator = runFlowAndGetPayload("get-events");
@@ -149,9 +147,7 @@ public class GetEventsTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        Calendar calendar = getTestRunMessageValue("calendar");
-        deleteCalendar(calendar);
-
+        runFlowAndGetPayload("delete-calendar");
     }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetFreeTimeTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetFreeTimeTestCases.java
@@ -10,77 +10,73 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import com.google.api.services.calendar.model.FreeBusyCalendar;
+import com.google.api.services.calendar.model.TimePeriod;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.module.google.calendar.model.FreeBusy;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-import com.google.api.services.calendar.model.FreeBusyCalendar;
-import com.google.api.services.calendar.model.TimePeriod;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class GetFreeTimeTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("getFreeTime");
-			
-			// Insert the calendar and the event
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			Event event = insertEvent(calendar, (Event) getTestRunMessageValue("event"));
-			
-			// Replace the existing "event" bean with the updated one
-			upsertOnTestRunMessage("event", event);
-			upsertOnTestRunMessage("eventId", event.getId());
-			upsertOnTestRunMessage("calendar", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-			
-	}
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("getFreeTime");
 
-	@Category({RegressionTests.class})	
-	@Test
-	public void testGetFreeTime() {
-		try {
-			String calendarId = getTestRunMessageValue("calendarId");
-			Event event = getTestRunMessageValue("event");
-			
-			List<String> calendarIds = new ArrayList<String>();
-			calendarIds.add(calendarId);
-			
-			upsertOnTestRunMessage("ids", calendarIds);
-			
-			FreeBusy freeBusy = runFlowAndGetPayload("get-free-time");
-								
-			// We should only be working with the calendar created specifically for this test
-			FreeBusyCalendar freeBusyCalendar = freeBusy.getCalendars().get(calendarId);
-			
-			List<TimePeriod> busyTimePeriods = freeBusyCalendar.getBusy();
-			assertTrue(busyTimePeriods.size() == 1);
-			
-			TimePeriod busyTimePeriod = busyTimePeriods.get(0);
-			assertTrue(busyTimePeriod.getStart().equals(event.getStart().getDateTime().getWrapped()));
-			assertTrue(busyTimePeriod.getEnd().equals(event.getEnd().getDateTime().getWrapped()));
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
-	}
-	
+        // Insert the calendar and the event
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+        Event event = insertEvent(calendar, (Event) getTestRunMessageValue("event"));
+
+        // Replace the existing "event" bean with the updated one
+        upsertOnTestRunMessage("event", event);
+        upsertOnTestRunMessage("eventId", event.getId());
+        upsertOnTestRunMessage("calendar", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testGetFreeTime() {
+        try {
+            String calendarId = getTestRunMessageValue("calendarId");
+            Event event = getTestRunMessageValue("event");
+
+            List<String> calendarIds = new ArrayList<String>();
+            calendarIds.add(calendarId);
+
+            upsertOnTestRunMessage("ids", calendarIds);
+
+            FreeBusy freeBusy = runFlowAndGetPayload("get-free-time");
+
+            // We should only be working with the calendar created specifically for this test
+            FreeBusyCalendar freeBusyCalendar = freeBusy.getCalendars().get(calendarId);
+
+            List<TimePeriod> busyTimePeriods = freeBusyCalendar.getBusy();
+            assertTrue(busyTimePeriods.size() == 1);
+
+            TimePeriod busyTimePeriod = busyTimePeriods.get(0);
+            assertTrue(busyTimePeriod.getStart().equals(event.getStart().getDateTime().getWrapped()));
+            assertTrue(busyTimePeriod.getEnd().equals(event.getEnd().getDateTime().getWrapped()));
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetFreeTimeTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetFreeTimeTestCases.java
@@ -38,8 +38,6 @@ public class GetFreeTimeTestCases extends GoogleCalendarTestParent {
 
         Event event = insertEvent((Event) getTestRunMessageValue("event"));
 
-        // Replace the existing "event" bean with the updated one
-        upsertOnTestRunMessage("event", event);
         upsertOnTestRunMessage("eventId", event.getId());
     }
 
@@ -64,8 +62,8 @@ public class GetFreeTimeTestCases extends GoogleCalendarTestParent {
             assertTrue(busyTimePeriods.size() == 1);
 
             TimePeriod busyTimePeriod = busyTimePeriods.get(0);
-            assertTrue(busyTimePeriod.getStart().toString().substring(0, 10).equals(event.getStart().getDateTime().getWrapped().toString().substring(0, 10)));
-            assertTrue(busyTimePeriod.getEnd().toString().substring(0, 10).equals(event.getEnd().getDateTime().getWrapped().toString().substring(0, 10)));
+            assertTrue(busyTimePeriod.getStart().equals(event.getStart().getDateTime().getWrapped()));
+            assertTrue(busyTimePeriod.getEnd().equals(event.getEnd().getDateTime().getWrapped()));
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetFreeTimeTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetFreeTimeTestCases.java
@@ -33,16 +33,14 @@ public class GetFreeTimeTestCases extends GoogleCalendarTestParent {
     public void setUp() throws Exception {
         initializeTestRunMessage("getFreeTime");
 
-        // Insert the calendar and the event
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-        Event event = insertEvent(calendar, (Event) getTestRunMessageValue("event"));
+        Calendar calendar = runFlowAndGetPayload("get-calendar-by-id");
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+        Event event = insertEvent((Event) getTestRunMessageValue("event"));
 
         // Replace the existing "event" bean with the updated one
         upsertOnTestRunMessage("event", event);
         upsertOnTestRunMessage("eventId", event.getId());
-        upsertOnTestRunMessage("calendar", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
-
     }
 
     @Category({RegressionTests.class})
@@ -66,8 +64,8 @@ public class GetFreeTimeTestCases extends GoogleCalendarTestParent {
             assertTrue(busyTimePeriods.size() == 1);
 
             TimePeriod busyTimePeriod = busyTimePeriods.get(0);
-            assertTrue(busyTimePeriod.getStart().equals(event.getStart().getDateTime().getWrapped()));
-            assertTrue(busyTimePeriod.getEnd().equals(event.getEnd().getDateTime().getWrapped()));
+            assertTrue(busyTimePeriod.getStart().toString().substring(0, 10).equals(event.getStart().getDateTime().getWrapped().toString().substring(0, 10)));
+            assertTrue(busyTimePeriod.getEnd().toString().substring(0, 10).equals(event.getEnd().getDateTime().getWrapped().toString().substring(0, 10)));
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
@@ -75,8 +73,7 @@ public class GetFreeTimeTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
+        runFlowAndGetPayload("delete-event");
     }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetInstancesTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetInstancesTestCases.java
@@ -10,63 +10,62 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
+import org.mule.streaming.ConsumerIterator;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class GetInstancesTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
 
-			loadTestRunMessage("getInstances");
+        initializeTestRunMessage("getInstances");
 
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-			
-			// Insert the event			
-			Event returnedEvent = runFlowAndGetPayload("insert-event");
-			upsertOnTestRunMessage("event", returnedEvent);
-			upsertOnTestRunMessage("eventId", returnedEvent.getId());
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
 
-	}
-	
-	@Category({RegressionTests.class})	
-	@Test
-	public void testGetInstances() {
-		try {
-			
-			String eventId = getTestRunMessageValue("eventId");		
-			List<Event> returnedEvent = runFlowAndGetPayload("get-instances");
-			
-			for (Event event : returnedEvent) {
-				assertEquals(event.getId(), eventId);
-			}
-				
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
-	}
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+        // Insert the event
+        Event returnedEvent = runFlowAndGetPayload("insert-event");
+        upsertOnTestRunMessage("event", returnedEvent);
+        upsertOnTestRunMessage("eventId", returnedEvent.getId());
+
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testGetInstances() {
+        try {
+
+            String eventId = getTestRunMessageValue("eventId");
+            ConsumerIterator<Event> consumerIterator = runFlowAndGetPayload("get-instances");
+            List<Event> returnedEvent = Lists.newArrayList(consumerIterator);
+            for (Event event : returnedEvent) {
+                assertEquals(event.getId(), eventId);
+            }
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+    }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GetInstancesTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GetInstancesTestCases.java
@@ -14,7 +14,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GoogleCalendarTestParent.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GoogleCalendarTestParent.java
@@ -17,7 +17,6 @@ import org.mule.api.config.MuleProperties;
 import org.mule.api.store.ObjectStore;
 import org.mule.api.store.ObjectStoreException;
 import org.mule.common.security.oauth.OAuthState;
-import org.mule.module.google.calendar.model.AclRule;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.google.api.client.batch.BatchResponse;
@@ -38,44 +37,27 @@ public class GoogleCalendarTestParent extends ConnectorTestCase {
         objectStore.store("accessTokenId", (OAuthState) getBeanFromContext("connectorOAuthState"));
     }
 
+    protected <T> T runFlowAndGetPayload(String flowName) throws Exception {
+        T messagePayload = super.runFlowAndGetPayload(flowName);
+        // Slow down the calls to api to avoid Calendar usage limit exceeded.
+        Thread.sleep(10000);
+        return messagePayload;
+    }
+
+    protected <T> T runFlowAndGetPayload(String flowName, String beanId) throws Exception {
+        T messagePayload = super.runFlowAndGetPayload(flowName, beanId);
+        // Slow down the calls to api to avoid Calendar usage limit exceeded.
+        Thread.sleep(10000);
+        return messagePayload;
+    }
+
 	/*
-	 * Helper methods below
+     * Helper methods below
 	 */
-
-    protected Calendar getPrimaryCalendar() throws Exception {
-        return getCalendar("primary");
-    }
-
-    protected Calendar getCalendar(String id) throws Exception {
-        upsertOnTestRunMessage("id", id);
-        return runFlowAndGetPayload("get-calendar-by-id");
-    }
-
-    protected void clearPrimaryCalendar() throws Exception {
-        clearCalendar("primary");
-    }
-
-    protected void clearCalendar(Calendar calendar) throws Exception {
-        clearCalendar(calendar.getId());
-    }
-
-    protected void clearCalendar(String id) throws Exception {
-        upsertOnTestRunMessage("id", id);
-        runFlowAndGetPayload("clear-calendar");
-    }
 
     protected BatchResponse<Calendar> insertCalendars(List<Calendar> calendars) throws Exception {
         upsertOnTestRunMessage("calendarsRef", calendars);
         return runFlowAndGetPayload("batch-insert-calendar");
-    }
-
-    protected void deleteCalendar(Calendar calendar) throws Exception {
-        deleteCalendar(calendar.getId());
-    }
-
-    protected void deleteCalendar(String id) throws Exception {
-        upsertOnTestRunMessage("id", id);
-        runFlowAndGetPayload("delete-calendar");
     }
 
     protected void deleteCalendars(List<Calendar> calendars) throws Exception {
@@ -83,68 +65,18 @@ public class GoogleCalendarTestParent extends ConnectorTestCase {
         runFlowAndGetPayload("batch-delete-calendar");
     }
 
-    protected Event quickAddEvent(Calendar calendar, String eventSummary) throws Exception {
-        return quickAddEvent(calendar.getId(), eventSummary);
-    }
-
-    protected Event quickAddEvent(String calendarId, String eventSummary) throws Exception {
-        upsertOnTestRunMessage("calendarId", calendarId);
-        upsertOnTestRunMessage("text", eventSummary);
-        return runFlowAndGetPayload("quick-add-event");
-    }
-
-    protected Event insertEvent(Calendar calendar, Event event) throws Exception {
-        return insertEvent(calendar.getId(), event);
-    }
-
-    protected Event insertEvent(String calendarId, Event event) throws Exception {
-        upsertOnTestRunMessage("calendarId", calendarId);
+    protected Event insertEvent(Event event) throws Exception {
         upsertOnTestRunMessage("calendarEventRef", event);
         return runFlowAndGetPayload("insert-event");
     }
 
-    protected BatchResponse<Event> insertEvents(Calendar calendar, List<Event> events) throws Exception {
-        return insertEvents(calendar.getId(), events);
-    }
-
-    protected BatchResponse<Event> insertEvents(String calendarId, List<Event> events) throws Exception {
-        upsertOnTestRunMessage("calendarId", calendarId);
+    protected BatchResponse<Event> insertEvents(List<Event> events) throws Exception {
         upsertOnTestRunMessage("calendarEventsRef", events);
         return runFlowAndGetPayload("batch-insert-event");
     }
 
-    protected void deleteEvent(String calendarId, Event event) throws Exception {
-        deleteEvent(calendarId, event.getId());
-    }
-
-    protected void deleteEvent(Calendar calendar, Event event) throws Exception {
-        deleteEvent(calendar.getId(), event.getId());
-    }
-
-    protected void deleteEvent(String calendarId, String eventId) throws Exception {
-        upsertOnTestRunMessage("calendarId", calendarId);
-        upsertOnTestRunMessage("eventId", eventId);
-        runFlowAndGetPayload("delete-event");
-    }
-
-    protected void deleteEvents(Calendar calendar, List<Event> events) throws Exception {
-        deleteEvents(calendar.getId(), events);
-    }
-
-    protected void deleteEvents(String calendarId, List<Event> events) throws Exception {
-        upsertOnTestRunMessage("calendarId", calendarId);
+    protected void deleteEvents(List<Event> events) throws Exception {
         upsertOnTestRunMessage("calendarEventsRef", events);
         runFlowAndGetPayload("batch-delete-event");
     }
-
-    protected void deleteAclRule(Calendar calendar, AclRule aclRule) throws Exception {
-        deleteAclRule(calendar.getId(), aclRule.getId());
-    }
-
-    protected void deleteAclRule(String calendarId, String ruleId) throws Exception {
-        upsertOnTestRunMessage("calendarId", calendarId);
-        upsertOnTestRunMessage("ruleId", ruleId);
-        runFlowAndGetPayload("delete-acl-rule");
-    }
-
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/GoogleCalendarTestParent.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/GoogleCalendarTestParent.java
@@ -10,8 +10,6 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
@@ -25,126 +23,128 @@ import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.google.api.client.batch.BatchResponse;
 import org.mule.modules.tests.ConnectorTestCase;
 
+import java.util.List;
+
 public class GoogleCalendarTestParent extends ConnectorTestCase {
 
-	// Set global timeout of tests to 10minutes
+    // Set global timeout of tests to 10minutes
     @Rule
     public Timeout globalTimeout = new Timeout(600000);
-	
-	
-	@Before
-	public void init() throws ObjectStoreException, Exception {
-		ObjectStore objectStore = muleContext.getRegistry().lookupObject(MuleProperties.DEFAULT_USER_OBJECT_STORE_NAME);
-		objectStore.store("accessTokenId", (OAuthState) getBeanFromContext("connectorOAuthState"));
-	}
-		
+
+
+    @Before
+    public void init() throws ObjectStoreException, Exception {
+        ObjectStore objectStore = muleContext.getRegistry().lookupObject(MuleProperties.DEFAULT_USER_OBJECT_STORE_NAME);
+        objectStore.store("accessTokenId", (OAuthState) getBeanFromContext("connectorOAuthState"));
+    }
+
 	/*
 	 * Helper methods below
 	 */
-	
-	protected Calendar getPrimaryCalendar() throws Exception {
-		return getCalendar("primary");
-	}
-	
-	protected Calendar getCalendar(String id) throws Exception {
-		upsertOnTestRunMessage("id", id);
-		return runFlowAndGetPayload("get-calendar-by-id");
-	}
-	
-	protected void clearPrimaryCalendar() throws Exception {
-		clearCalendar("primary");
-	}
-	
-	protected void clearCalendar(Calendar calendar) throws Exception {
-		clearCalendar(calendar.getId());
-	}
-	
-	protected void clearCalendar(String id) throws Exception {
-		upsertOnTestRunMessage("id", id);
-		runFlowAndGetPayload("clear-calendar");
-	}
-	
-	protected BatchResponse<Calendar> insertCalendars(List<Calendar> calendars) throws Exception {
-		upsertOnTestRunMessage("calendarsRef", calendars);
-		return runFlowAndGetPayload("batch-insert-calendar");
-	}
-		
-	protected void deleteCalendar(Calendar calendar) throws Exception {
-		deleteCalendar(calendar.getId());
-	}
-	
-	protected void deleteCalendar(String id) throws Exception {
-		upsertOnTestRunMessage("id", id);
-		runFlowAndGetPayload("delete-calendar");
-	}
-	
-	protected void deleteCalendars(List<Calendar> calendars) throws Exception {
-		upsertOnTestRunMessage("calendarsRef", calendars);
-		runFlowAndGetPayload("batch-delete-calendar");
-	}
-	
-	protected Event quickAddEvent(Calendar calendar, String eventSummary) throws Exception {
-		return quickAddEvent(calendar.getId(), eventSummary);
-	}
-	
-	protected Event quickAddEvent(String calendarId, String eventSummary) throws Exception {
-		upsertOnTestRunMessage("calendarId", calendarId);
-		upsertOnTestRunMessage("text", eventSummary);
-		return runFlowAndGetPayload("quick-add-event");
-	}
-	
-	protected Event insertEvent(Calendar calendar, Event event) throws Exception {
-		return insertEvent(calendar.getId(), event);
-	}
-	
-	protected Event insertEvent(String calendarId, Event event) throws Exception {
-		upsertOnTestRunMessage("calendarId", calendarId);
-		upsertOnTestRunMessage("calendarEventRef", event);
-		return runFlowAndGetPayload("insert-event");
-	}
-	
-	protected BatchResponse<Event> insertEvents(Calendar calendar, List<Event> events) throws Exception {
-		return insertEvents(calendar.getId(), events);
-	}
-	
-	protected BatchResponse<Event> insertEvents(String calendarId, List<Event> events) throws Exception {
-		upsertOnTestRunMessage("calendarId", calendarId);
-		upsertOnTestRunMessage("calendarEventsRef", events);
-		return runFlowAndGetPayload("batch-insert-event");
-	}
-	
-	protected void deleteEvent(String calendarId, Event event) throws Exception {
-		deleteEvent(calendarId, event.getId());
-	}
-	
-	protected void deleteEvent(Calendar calendar, Event event) throws Exception {
-		deleteEvent(calendar.getId(), event.getId());
-	}
-	
-	protected void deleteEvent(String calendarId, String eventId) throws Exception {
-		upsertOnTestRunMessage("calendarId", calendarId);
-		upsertOnTestRunMessage("eventId", eventId);
-		runFlowAndGetPayload("delete-event");
-	}
-	
-	protected void deleteEvents(Calendar calendar, List<Event> events) throws Exception {
-		deleteEvents(calendar.getId(), events);
-	}
-	
-	protected void deleteEvents(String calendarId, List<Event> events) throws Exception {
-		upsertOnTestRunMessage("calendarId", calendarId);
-		upsertOnTestRunMessage("calendarEventsRef", events);
-		runFlowAndGetPayload("batch-delete-event");
-	}
-	
-	protected void deleteAclRule(Calendar calendar, AclRule aclRule) throws Exception {
-		deleteAclRule(calendar.getId(), aclRule.getId());
-	}
-	
-	protected void deleteAclRule(String calendarId, String ruleId) throws Exception {
-		upsertOnTestRunMessage("calendarId", calendarId);
-		upsertOnTestRunMessage("ruleId", ruleId);
-		runFlowAndGetPayload("delete-acl-rule");
-	}
-	
+
+    protected Calendar getPrimaryCalendar() throws Exception {
+        return getCalendar("primary");
+    }
+
+    protected Calendar getCalendar(String id) throws Exception {
+        upsertOnTestRunMessage("id", id);
+        return runFlowAndGetPayload("get-calendar-by-id");
+    }
+
+    protected void clearPrimaryCalendar() throws Exception {
+        clearCalendar("primary");
+    }
+
+    protected void clearCalendar(Calendar calendar) throws Exception {
+        clearCalendar(calendar.getId());
+    }
+
+    protected void clearCalendar(String id) throws Exception {
+        upsertOnTestRunMessage("id", id);
+        runFlowAndGetPayload("clear-calendar");
+    }
+
+    protected BatchResponse<Calendar> insertCalendars(List<Calendar> calendars) throws Exception {
+        upsertOnTestRunMessage("calendarsRef", calendars);
+        return runFlowAndGetPayload("batch-insert-calendar");
+    }
+
+    protected void deleteCalendar(Calendar calendar) throws Exception {
+        deleteCalendar(calendar.getId());
+    }
+
+    protected void deleteCalendar(String id) throws Exception {
+        upsertOnTestRunMessage("id", id);
+        runFlowAndGetPayload("delete-calendar");
+    }
+
+    protected void deleteCalendars(List<Calendar> calendars) throws Exception {
+        upsertOnTestRunMessage("calendarsRef", calendars);
+        runFlowAndGetPayload("batch-delete-calendar");
+    }
+
+    protected Event quickAddEvent(Calendar calendar, String eventSummary) throws Exception {
+        return quickAddEvent(calendar.getId(), eventSummary);
+    }
+
+    protected Event quickAddEvent(String calendarId, String eventSummary) throws Exception {
+        upsertOnTestRunMessage("calendarId", calendarId);
+        upsertOnTestRunMessage("text", eventSummary);
+        return runFlowAndGetPayload("quick-add-event");
+    }
+
+    protected Event insertEvent(Calendar calendar, Event event) throws Exception {
+        return insertEvent(calendar.getId(), event);
+    }
+
+    protected Event insertEvent(String calendarId, Event event) throws Exception {
+        upsertOnTestRunMessage("calendarId", calendarId);
+        upsertOnTestRunMessage("calendarEventRef", event);
+        return runFlowAndGetPayload("insert-event");
+    }
+
+    protected BatchResponse<Event> insertEvents(Calendar calendar, List<Event> events) throws Exception {
+        return insertEvents(calendar.getId(), events);
+    }
+
+    protected BatchResponse<Event> insertEvents(String calendarId, List<Event> events) throws Exception {
+        upsertOnTestRunMessage("calendarId", calendarId);
+        upsertOnTestRunMessage("calendarEventsRef", events);
+        return runFlowAndGetPayload("batch-insert-event");
+    }
+
+    protected void deleteEvent(String calendarId, Event event) throws Exception {
+        deleteEvent(calendarId, event.getId());
+    }
+
+    protected void deleteEvent(Calendar calendar, Event event) throws Exception {
+        deleteEvent(calendar.getId(), event.getId());
+    }
+
+    protected void deleteEvent(String calendarId, String eventId) throws Exception {
+        upsertOnTestRunMessage("calendarId", calendarId);
+        upsertOnTestRunMessage("eventId", eventId);
+        runFlowAndGetPayload("delete-event");
+    }
+
+    protected void deleteEvents(Calendar calendar, List<Event> events) throws Exception {
+        deleteEvents(calendar.getId(), events);
+    }
+
+    protected void deleteEvents(String calendarId, List<Event> events) throws Exception {
+        upsertOnTestRunMessage("calendarId", calendarId);
+        upsertOnTestRunMessage("calendarEventsRef", events);
+        runFlowAndGetPayload("batch-delete-event");
+    }
+
+    protected void deleteAclRule(Calendar calendar, AclRule aclRule) throws Exception {
+        deleteAclRule(calendar.getId(), aclRule.getId());
+    }
+
+    protected void deleteAclRule(String calendarId, String ruleId) throws Exception {
+        upsertOnTestRunMessage("calendarId", calendarId);
+        upsertOnTestRunMessage("ruleId", ruleId);
+        runFlowAndGetPayload("delete-acl-rule");
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/ImportEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/ImportEventTestCases.java
@@ -10,68 +10,63 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
-import org.mule.module.google.calendar.model.EventDateTime;
 import org.mule.modules.tests.ConnectorTestUtils;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ImportEventTestCases extends GoogleCalendarTestParent {
 
-	@SuppressWarnings("unchecked")
-	@Before
-	public void setUp() throws Exception {
-		loadTestRunMessage("importEvent");
-		
-		// Insert the calendar
-		Calendar calendar = runFlowAndGetPayload("create-calendar");
-		
-		upsertOnTestRunMessage("calendar", calendar);
-		upsertOnTestRunMessage("calendarId", calendar.getId());
-			
-	}
-	
-	@Category({RegressionTests.class})
-	@Test
-	public void testImportEvent() {
-		try {
-			// Get calendar instance
-			Calendar calendar = getTestRunMessageValue("calendar");
-			// Insert the event so that we get ID, and iCalUID
-			Event event = insertEvent(calendar, (Event) getTestRunMessageValue("event"));
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("importEvent");
 
-			// Place it in testObjects so that we can import it back
-			upsertOnTestRunMessage("calendarEventRef", event);
-			
-			// Re-import the event again	
-			// Check that the returned event as it was imported is identical to the one which was placed the first time
-			Event returnedEvent = runFlowAndGetPayload("import-event");
-			assertTrue(EqualsBuilder.reflectionEquals(returnedEvent.getSummary(), event.getSummary()));
-			assertTrue(EqualsBuilder.reflectionEquals(returnedEvent.getStart(), event.getStart()));
-			assertTrue(EqualsBuilder.reflectionEquals(returnedEvent.getEnd(), event.getEnd()));
-			assertTrue(EqualsBuilder.reflectionEquals(returnedEvent.getICalUID(), event.getICalUID()));
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
+        // Insert the calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
 
-			Calendar calendar = getTestRunMessageValue("calendar");
-			deleteCalendar(calendar);
+        upsertOnTestRunMessage("calendar", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
 
-	}
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testImportEvent() {
+        try {
+            // Get calendar instance
+            Calendar calendar = getTestRunMessageValue("calendar");
+            // Insert the event so that we get ID, and iCalUID
+            Event event = insertEvent(calendar, (Event) getTestRunMessageValue("event"));
+
+            // Place it in testObjects so that we can import it back
+            upsertOnTestRunMessage("calendarEventRef", event);
+
+            // Re-import the event again
+            // Check that the returned event as it was imported is identical to the one which was placed the first time
+            Event returnedEvent = runFlowAndGetPayload("import-event");
+            assertTrue(EqualsBuilder.reflectionEquals(returnedEvent.getSummary(), event.getSummary()));
+            assertTrue(EqualsBuilder.reflectionEquals(returnedEvent.getStart(), event.getStart()));
+            assertTrue(EqualsBuilder.reflectionEquals(returnedEvent.getEnd(), event.getEnd()));
+            assertTrue(EqualsBuilder.reflectionEquals(returnedEvent.getICalUID(), event.getICalUID()));
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        Calendar calendar = getTestRunMessageValue("calendar");
+        deleteCalendar(calendar);
+
+    }
 }
 

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/ImportEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/ImportEventTestCases.java
@@ -28,25 +28,17 @@ public class ImportEventTestCases extends GoogleCalendarTestParent {
     @Before
     public void setUp() throws Exception {
         initializeTestRunMessage("importEvent");
-
-        // Insert the calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        upsertOnTestRunMessage("calendar", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
-
     }
 
     @Category({RegressionTests.class})
     @Test
     public void testImportEvent() {
         try {
-            // Get calendar instance
-            Calendar calendar = getTestRunMessageValue("calendar");
             // Insert the event so that we get ID, and iCalUID
-            Event event = insertEvent(calendar, (Event) getTestRunMessageValue("event"));
+            Event event = insertEvent((Event) getTestRunMessageValue("event"));
 
             // Place it in testObjects so that we can import it back
+            upsertOnTestRunMessage("eventId", event.getId());
             upsertOnTestRunMessage("calendarEventRef", event);
 
             // Re-import the event again
@@ -63,10 +55,7 @@ public class ImportEventTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-
-        Calendar calendar = getTestRunMessageValue("calendar");
-        deleteCalendar(calendar);
-
+        runFlowAndGetPayload("delete-event");
     }
 }
 

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/InsertAclRuleTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/InsertAclRuleTestCases.java
@@ -10,70 +10,60 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.AclRule;
 import org.mule.module.google.calendar.model.Calendar;
-import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-public class InsertAclRuleTestCases  extends GoogleCalendarTestParent {
-	
-	@Before
-	public void setUp() throws Exception {
-		try {
-			loadTestRunMessage("insertAclRule");
-			
-			// Insert calendar and get reference to retrieved calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Replace old calendar instance with new instance
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail();
-		}
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})	
-	@Test
-	public void testInsertAclRule(){
-		try {
+import static org.junit.Assert.*;
 
-			AclRule returnedAclRule = runFlowAndGetPayload("insert-acl-rule");
-			String ruleId = returnedAclRule.getId();
-		
-			upsertOnTestRunMessage("ruleId", ruleId);
-		
-			AclRule afterProc = runFlowAndGetPayload("get-acl-rule-by-id");
-			String ruleIdAfter = afterProc.getId();
-			
-			assertEquals(ruleId,ruleIdAfter);
-			assertTrue(EqualsBuilder.reflectionEquals(returnedAclRule, afterProc));
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}		
-	}
-		
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
+public class InsertAclRuleTestCases extends GoogleCalendarTestParent {
 
-	}
+    @Before
+    public void setUp() throws Exception {
+        try {
+            initializeTestRunMessage("insertAclRule");
+
+            // Insert calendar and get reference to retrieved calendar
+            Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+            // Replace old calendar instance with new instance
+            upsertOnTestRunMessage("calendarRef", calendar);
+            upsertOnTestRunMessage("calendarId", calendar.getId());
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testInsertAclRule() {
+        try {
+
+            AclRule returnedAclRule = runFlowAndGetPayload("insert-acl-rule");
+            String ruleId = returnedAclRule.getId();
+
+            upsertOnTestRunMessage("ruleId", ruleId);
+
+            AclRule afterProc = runFlowAndGetPayload("get-acl-rule-by-id");
+            String ruleIdAfter = afterProc.getId();
+
+            assertEquals(ruleId, ruleIdAfter);
+            assertTrue(EqualsBuilder.reflectionEquals(returnedAclRule, afterProc));
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/InsertAclRuleTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/InsertAclRuleTestCases.java
@@ -16,7 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mule.module.google.calendar.model.AclRule;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
 import static org.junit.Assert.*;
@@ -25,18 +24,7 @@ public class InsertAclRuleTestCases extends GoogleCalendarTestParent {
 
     @Before
     public void setUp() throws Exception {
-        try {
-            initializeTestRunMessage("insertAclRule");
-
-            // Insert calendar and get reference to retrieved calendar
-            Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-            // Replace old calendar instance with new instance
-            upsertOnTestRunMessage("calendarRef", calendar);
-            upsertOnTestRunMessage("calendarId", calendar.getId());
-        } catch (Exception e) {
-            fail(ConnectorTestUtils.getStackTrace(e));
-        }
+        initializeTestRunMessage("insertAclRule");
     }
 
     @Category({SmokeTests.class, RegressionTests.class})
@@ -61,9 +49,6 @@ public class InsertAclRuleTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
-
+        runFlowAndGetPayload("delete-acl-rule");
     }
-
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/InsertEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/InsertEventTestCases.java
@@ -26,13 +26,6 @@ public class InsertEventTestCases extends GoogleCalendarTestParent {
     @Before
     public void setUp() throws Exception {
         initializeTestRunMessage("insertEvent");
-
-        // Insert calendar and get reference to retrieved calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Replace old calendar instance with new instance
-        upsertOnTestRunMessage("calendarRef", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
     }
 
     @Category({SmokeTests.class, RegressionTests.class})
@@ -58,11 +51,6 @@ public class InsertEventTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
-
+        runFlowAndGetPayload("delete-event");
     }
-
-
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/InsertEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/InsertEventTestCases.java
@@ -10,65 +10,59 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.*;
+
 public class InsertEventTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-		loadTestRunMessage("insertEvent");
-		
-		// Insert calendar and get reference to retrieved calendar
-		Calendar calendar = runFlowAndGetPayload("create-calendar");
-		
-		// Replace old calendar instance with new instance
-		upsertOnTestRunMessage("calendarRef", calendar);
-		upsertOnTestRunMessage("calendarId", calendar.getId());
-	}
-	
-	@Category({SmokeTests.class, RegressionTests.class})	
-	@Test
-	public void testInsertEvent() {
-		try {
-			
-			Event event = runFlowAndGetPayload("insert-event");
-			assertNotNull(event);
-			
-			upsertOnTestRunMessage("event", event);
-			upsertOnTestRunMessage("eventId", event.getId());
-			
-			Event returnedEvent = runFlowAndGetPayload("get-event-by-id");
-			
-			assertTrue(event.getId().equals(returnedEvent.getId()));
-			assertTrue(EqualsBuilder.reflectionEquals(event, returnedEvent));
-		
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("insertEvent");
 
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
-		
-	}
-	
-	
+        // Insert calendar and get reference to retrieved calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+        // Replace old calendar instance with new instance
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+    }
+
+    @Category({SmokeTests.class, RegressionTests.class})
+    @Test
+    public void testInsertEvent() {
+        try {
+
+            Event event = runFlowAndGetPayload("insert-event");
+            assertNotNull(event);
+
+            upsertOnTestRunMessage("event", event);
+            upsertOnTestRunMessage("eventId", event.getId());
+
+            Event returnedEvent = runFlowAndGetPayload("get-event-by-id");
+
+            assertTrue(event.getId().equals(returnedEvent.getId()));
+            assertTrue(EqualsBuilder.reflectionEquals(event, returnedEvent));
+
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
+
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/MoveEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/MoveEventTestCases.java
@@ -10,73 +10,68 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
-import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class MoveEventTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("moveEvent");
-			
-			// Insert the source calendar and target calendar
-			upsertOnTestRunMessage("calendarRef", getTestRunMessageValue("sourceCalendarRef"));
-			Calendar sourceCalendar = runFlowAndGetPayload("create-calendar");
-			upsertOnTestRunMessage("calendarRef", getTestRunMessageValue("targetCalendarRef"));
-			Calendar targetCalendar = runFlowAndGetPayload("create-calendar");
-			
-			// Place updated calendars and their IDs into testObjects
-			upsertOnTestRunMessage("sourceCalendarRef", sourceCalendar);
-			upsertOnTestRunMessage("sourceCalendarId", sourceCalendar.getId());
-			upsertOnTestRunMessage("targetCalendarRef", targetCalendar);
-			upsertOnTestRunMessage("targetCalendarId", targetCalendar.getId());
-			
-			// Insert an event into the source calendar
-			Event event = insertEvent(sourceCalendar, (Event) getTestRunMessageValue("event"));
-			upsertOnTestRunMessage("event", event);
-			upsertOnTestRunMessage("eventId", event.getId());
-		
-	}
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("moveEvent");
 
-	@Category({RegressionTests.class})	
-	@Test
-	public void testMoveEvent() {
-		try {
-			Calendar targetCalendar = getTestRunMessageValue("targetCalendarRef");
-			
-			// Move the event from the source calendar to the target calendar
-			Event movedEvent = runFlowAndGetPayload("move-event");
+        // Insert the source calendar and target calendar
+        upsertOnTestRunMessage("calendarRef", getTestRunMessageValue("sourceCalendarRef"));
+        Calendar sourceCalendar = runFlowAndGetPayload("create-calendar");
+        upsertOnTestRunMessage("calendarRef", getTestRunMessageValue("targetCalendarRef"));
+        Calendar targetCalendar = runFlowAndGetPayload("create-calendar");
 
-			// Perform assertions on the returned event
-			assertTrue(movedEvent.getStatus().equals("cancelled")); // Default return status when moving an event
-			assertTrue(movedEvent.getOrganizer().getDisplayName().equals(targetCalendar.getSummary()));
-			assertTrue(movedEvent.getOrganizer().getEmail().equals(targetCalendar.getId())); 						
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
+        // Place updated calendars and their IDs into testObjects
+        upsertOnTestRunMessage("sourceCalendarRef", sourceCalendar);
+        upsertOnTestRunMessage("sourceCalendarId", sourceCalendar.getId());
+        upsertOnTestRunMessage("targetCalendarRef", targetCalendar);
+        upsertOnTestRunMessage("targetCalendarId", targetCalendar.getId());
 
-			Calendar sourceCalendar = getTestRunMessageValue("sourceCalendarRef");
-			Calendar targetCalendar = getTestRunMessageValue("targetCalendarRef");
-			
-			deleteCalendar(sourceCalendar);
-			deleteCalendar(targetCalendar);
+        // Insert an event into the source calendar
+        Event event = insertEvent(sourceCalendar, (Event) getTestRunMessageValue("event"));
+        upsertOnTestRunMessage("event", event);
+        upsertOnTestRunMessage("eventId", event.getId());
 
-	}
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testMoveEvent() {
+        try {
+            Calendar targetCalendar = getTestRunMessageValue("targetCalendarRef");
+
+            // Move the event from the source calendar to the target calendar
+            Event movedEvent = runFlowAndGetPayload("move-event");
+
+            // Perform assertions on the returned event
+            assertTrue(movedEvent.getStatus().equals("cancelled")); // Default return status when moving an event
+            assertTrue(movedEvent.getOrganizer().getDisplayName().equals(targetCalendar.getSummary()));
+            assertTrue(movedEvent.getOrganizer().getEmail().equals(targetCalendar.getId()));
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        Calendar sourceCalendar = getTestRunMessageValue("sourceCalendarRef");
+        Calendar targetCalendar = getTestRunMessageValue("targetCalendarRef");
+
+        deleteCalendar(sourceCalendar);
+        deleteCalendar(targetCalendar);
+
+    }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/QuickAddEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/QuickAddEventTestCases.java
@@ -10,69 +10,62 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.*;
+
 public class QuickAddEventTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("quickAddEvent");
-			
-			// Insert calendar and get reference to retrieved calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Replace old calendar instance with new instance
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-	}
-	
-	@Category({RegressionTests.class})	
-	@Test
-	public void testQuickAddEvent() {
-		try {
-			String text = getTestRunMessageValue("text");
-			
-			// Perform assertions on the event
-			Event createdEvent = runFlowAndGetPayload("quick-add-event");
-			assertNotNull(createdEvent);
-			assertTrue(createdEvent.getSummary().equals(text));
-			assertTrue(createdEvent.getStatus().equals("confirmed"));
-			
-			upsertOnTestRunMessage("event", createdEvent);
-			upsertOnTestRunMessage("eventId", createdEvent.getId());
-			
-			// Verify that the event was added on Google Calendars			
-			Event returnedEvent = runFlowAndGetPayload("get-event-by-id");
-			
-			// Assert that the created event and the returned are identical
-			assertTrue(EqualsBuilder.reflectionEquals(createdEvent, returnedEvent));
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			// Drop the calendar
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("quickAddEvent");
 
-	}
-	
-	
+        // Insert calendar and get reference to retrieved calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+        // Replace old calendar instance with new instance
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testQuickAddEvent() {
+        try {
+            String text = getTestRunMessageValue("text");
+
+            // Perform assertions on the event
+            Event createdEvent = runFlowAndGetPayload("quick-add-event");
+            assertNotNull(createdEvent);
+            assertTrue(createdEvent.getSummary().equals(text));
+            assertTrue(createdEvent.getStatus().equals("confirmed"));
+
+            upsertOnTestRunMessage("event", createdEvent);
+            upsertOnTestRunMessage("eventId", createdEvent.getId());
+
+            // Verify that the event was added on Google Calendars
+            Event returnedEvent = runFlowAndGetPayload("get-event-by-id");
+
+            // Assert that the created event and the returned are identical
+            assertTrue(EqualsBuilder.reflectionEquals(createdEvent, returnedEvent));
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Drop the calendar
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/QuickAddEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/QuickAddEventTestCases.java
@@ -26,13 +26,6 @@ public class QuickAddEventTestCases extends GoogleCalendarTestParent {
     @Before
     public void setUp() throws Exception {
         initializeTestRunMessage("quickAddEvent");
-
-        // Insert calendar and get reference to retrieved calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Replace old calendar instance with new instance
-        upsertOnTestRunMessage("calendarRef", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
     }
 
     @Category({RegressionTests.class})
@@ -62,10 +55,8 @@ public class QuickAddEventTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        // Drop the calendar
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
-
+        // Drop the event.
+        runFlowAndGetPayload("delete-event");
     }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateAclRuleTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateAclRuleTestCases.java
@@ -14,6 +14,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mule.module.google.calendar.ScopeRole;
 import org.mule.module.google.calendar.model.AclRule;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
@@ -27,15 +28,8 @@ public class UpdateAclRuleTestCases extends GoogleCalendarTestParent {
     public void setUp() throws Exception {
         initializeTestRunMessage("updateAclRule");
 
-        // Insert calendar and get reference to retrieved calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Replace old calendar instance with new instance
-        upsertOnTestRunMessage("calendarRef", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
-
-        String roleBefore = getTestRunMessageValue("roleBefore").toString();
-        upsertOnTestRunMessage("role", roleBefore);
+        ScopeRole roleBefore = getTestRunMessageValue("roleBefore");
+        upsertOnTestRunMessage("role", roleBefore.name());
 
         // Insert the ACL rule
 
@@ -44,30 +38,26 @@ public class UpdateAclRuleTestCases extends GoogleCalendarTestParent {
         upsertOnTestRunMessage("ruleId", returnedAclRule.getId());
     }
 
-
     @Category({RegressionTests.class})
     @Test
     public void testUpdateAclRule() {
         try {
-            String roleAfter = getTestRunMessageValue("roleAfter").toString();
+            ScopeRole roleAfter = getTestRunMessageValue("roleAfter");
 
             AclRule aclRule = getTestRunMessageValue("aclRule");
-            aclRule.setRole(roleAfter);
+            aclRule.setRole(roleAfter.name());
             upsertOnTestRunMessage("aclRuleRef", aclRule);
 
             aclRule = runFlowAndGetPayload("update-acl-rule");
             String roleAfterUpdate = aclRule.getRole();
-            assertEquals(roleAfter, roleAfterUpdate);
+            assertEquals(roleAfter.name(), roleAfterUpdate);
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
     }
 
-
     @After
     public void tearDown() throws Exception {
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
+       runFlowAndGetPayload("delete-acl-rule");
     }
-
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateAclRuleTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateAclRuleTestCases.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mule.module.google.calendar.ScopeRole;
 import org.mule.module.google.calendar.model.AclRule;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
 import static org.junit.Assert.assertEquals;
@@ -58,6 +57,6 @@ public class UpdateAclRuleTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-       runFlowAndGetPayload("delete-acl-rule");
+        runFlowAndGetPayload("delete-acl-rule");
     }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateAclRuleTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateAclRuleTestCases.java
@@ -10,69 +10,64 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.AclRule;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class UpdateAclRuleTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("updateAclRule");
-			
-			// Insert calendar and get reference to retrieved calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Replace old calendar instance with new instance
-			upsertOnTestRunMessage("calendarRef", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-			
-			String roleBefore = getTestRunMessageValue("roleBefore"); 
-			upsertOnTestRunMessage("role", roleBefore);
-		
-			// Insert the ACL rule
-						
-			AclRule returnedAclRule = runFlowAndGetPayload("insert-acl-rule");
-			upsertOnTestRunMessage("aclRule", returnedAclRule);	
-			upsertOnTestRunMessage("ruleId", returnedAclRule.getId());
-	}
-	
-	
-	@Category({ RegressionTests.class})
-	@Test
-	public void testUpdateAclRule() {
-		try {
-			String roleAfter = getTestRunMessageValue("roleAfter");
-			
-			AclRule aclRule = getTestRunMessageValue("aclRule");
-			aclRule.setRole(roleAfter);
-			upsertOnTestRunMessage("aclRuleRef", aclRule);			
-			
-			aclRule = runFlowAndGetPayload("update-acl-rule");
-			String roleAfterUpdate = aclRule.getRole();
-			assertEquals(roleAfter, roleAfterUpdate);
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
-	}
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("updateAclRule");
 
-	
+        // Insert calendar and get reference to retrieved calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+        // Replace old calendar instance with new instance
+        upsertOnTestRunMessage("calendarRef", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+        String roleBefore = getTestRunMessageValue("roleBefore").toString();
+        upsertOnTestRunMessage("role", roleBefore);
+
+        // Insert the ACL rule
+
+        AclRule returnedAclRule = runFlowAndGetPayload("insert-acl-rule");
+        upsertOnTestRunMessage("aclRule", returnedAclRule);
+        upsertOnTestRunMessage("ruleId", returnedAclRule.getId());
+    }
+
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testUpdateAclRule() {
+        try {
+            String roleAfter = getTestRunMessageValue("roleAfter").toString();
+
+            AclRule aclRule = getTestRunMessageValue("aclRule");
+            aclRule.setRole(roleAfter);
+            upsertOnTestRunMessage("aclRuleRef", aclRule);
+
+            aclRule = runFlowAndGetPayload("update-acl-rule");
+            String roleAfterUpdate = aclRule.getRole();
+            assertEquals(roleAfter, roleAfterUpdate);
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarListTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarListTestCases.java
@@ -28,14 +28,11 @@ public class UpdateCalendarListTestCases extends GoogleCalendarTestParent {
     public void setUp() throws Exception {
         initializeTestRunMessage("updateCalendarList");
 
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        upsertOnTestRunMessage("calendar", calendar);
-        upsertOnTestRunMessage("id", calendar.getId());
-
-        //Get Calendar List
+        // Get Calendar List
         CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
 
+        upsertOnTestRunMessage("calendarId", returnedCalendarList.getId());
+        upsertOnTestRunMessage("colorBefore", returnedCalendarList.getColorId());
         upsertOnTestRunMessage("calendarList", returnedCalendarList);
 
     }
@@ -55,6 +52,11 @@ public class UpdateCalendarListTestCases extends GoogleCalendarTestParent {
             CalendarList afterUpdate = runFlowAndGetPayload("update-calendar-list");
             String afterColorId = afterUpdate.getColorId();
             assertEquals(afterColorId, colorAfter);
+
+            // Update the list ref with the old values for tearDown.
+            String colorBefore =getTestRunMessageValue("colorBefore");
+            afterUpdate.setColorId(colorBefore);
+            upsertOnTestRunMessage("calendarListRef", afterUpdate);
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
@@ -62,9 +64,6 @@ public class UpdateCalendarListTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        String calendarId = getTestRunMessageValue("id");
-        deleteCalendar(calendarId);
-
+       runFlowAndGetPayload("update-calendar-list");
     }
-
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarListTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarListTestCases.java
@@ -10,66 +10,61 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-public class UpdateCalendarListTestCases extends GoogleCalendarTestParent{
-	
-	
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("updateCalendarList");
-	
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-						
-			upsertOnTestRunMessage("calendar", calendar);
-			upsertOnTestRunMessage("id", calendar.getId());
-			
-			//Get Calendar List 
-			CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
-			
-			upsertOnTestRunMessage("calendarList", returnedCalendarList);
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-	}
-	
-	
-	@Category({RegressionTests.class})
-	@Test
-	public void testUpdateCalendarList() {
-		try {
-			String colorAfter = runFlowAndGetPayload("colorAfter");
-			
-			CalendarList returnedCalendarList = getTestRunMessageValue("calendarList");
-			
-			returnedCalendarList.setColorId(colorAfter);
-			upsertOnTestRunMessage("calendarListRef", returnedCalendarList);
-			
-			CalendarList afterUpdate = runFlowAndGetPayload("update-calendar-list");
-			String afterColorId = afterUpdate.getColorId();
-			assertEquals(afterColorId, colorAfter);
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("id");
-			deleteCalendar(calendarId);
+public class UpdateCalendarListTestCases extends GoogleCalendarTestParent {
 
-	}
-	
+
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("updateCalendarList");
+
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+        upsertOnTestRunMessage("calendar", calendar);
+        upsertOnTestRunMessage("id", calendar.getId());
+
+        //Get Calendar List
+        CalendarList returnedCalendarList = runFlowAndGetPayload("get-calendar-list-by-id");
+
+        upsertOnTestRunMessage("calendarList", returnedCalendarList);
+
+    }
+
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testUpdateCalendarList() {
+        try {
+            String colorAfter = getTestRunMessageValue("colorAfter");
+
+            CalendarList returnedCalendarList = getTestRunMessageValue("calendarList");
+
+            returnedCalendarList.setColorId(colorAfter);
+            upsertOnTestRunMessage("calendarListRef", returnedCalendarList);
+
+            CalendarList afterUpdate = runFlowAndGetPayload("update-calendar-list");
+            String afterColorId = afterUpdate.getColorId();
+            assertEquals(afterColorId, colorAfter);
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("id");
+        deleteCalendar(calendarId);
+
+    }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarListTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarListTestCases.java
@@ -14,7 +14,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.CalendarList;
 import org.mule.modules.tests.ConnectorTestUtils;
 
@@ -54,7 +53,7 @@ public class UpdateCalendarListTestCases extends GoogleCalendarTestParent {
             assertEquals(afterColorId, colorAfter);
 
             // Update the list ref with the old values for tearDown.
-            String colorBefore =getTestRunMessageValue("colorBefore");
+            String colorBefore = getTestRunMessageValue("colorBefore");
             afterUpdate.setColorId(colorBefore);
             upsertOnTestRunMessage("calendarListRef", afterUpdate);
         } catch (Exception e) {
@@ -64,6 +63,6 @@ public class UpdateCalendarListTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-       runFlowAndGetPayload("update-calendar-list");
+        runFlowAndGetPayload("update-calendar-list");
     }
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarTestCases.java
@@ -26,28 +26,30 @@ public class UpdateCalendarTestCases extends GoogleCalendarTestParent {
     @Before
     public void setUp() throws Exception {
         initializeTestRunMessage("updateCalendar");
-
-        // Insert the calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Update test objects
-        upsertOnTestRunMessage("calendar", calendar);
-        upsertOnTestRunMessage("id", calendar.getId());
     }
 
     @Category({RegressionTests.class})
     @Test
     public void testUpdateCalendar() {
         try {
+            Calendar calendar = runFlowAndGetPayload("get-calendar-by-id");
+            String summaryBefore = calendar.getSummary();
+
+            upsertOnTestRunMessage("calendarId", calendar.getId());
+            upsertOnTestRunMessage("summaryBefore", summaryBefore != null ? summaryBefore : "");
+
             String summaryAfter = getTestRunMessageValue("summaryAfter");
 
-            Calendar calendar = getTestRunMessageValue("calendar");
             calendar.setSummary(summaryAfter);
             upsertOnTestRunMessage("calendarRef", calendar);
 
             Calendar afterUpdate = runFlowAndGetPayload("update-calendar");
             String afterText = afterUpdate.getSummary();
             assertEquals(afterText, summaryAfter);
+
+            // Set the summary back to summaryBefore for tearDown.
+            afterUpdate.setSummary(summaryBefore);
+            upsertOnTestRunMessage("calendarRef", afterUpdate);
         } catch (Exception e) {
             fail(ConnectorTestUtils.getStackTrace(e));
         }
@@ -55,8 +57,7 @@ public class UpdateCalendarTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        String calendarId = getTestRunMessageValue("id");
-        deleteCalendar(calendarId);
+        runFlowAndGetPayload("update-calendar");
     }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateCalendarTestCases.java
@@ -10,58 +10,53 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
-import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
-public class UpdateCalendarTestCases extends GoogleCalendarTestParent {
-	
-	
-	@Before
-	public void setUp() throws Exception {
-			loadTestRunMessage("updateCalendar");
-		
-			// Insert the calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Update test objects
-			upsertOnTestRunMessage("calendar", calendar);
-			upsertOnTestRunMessage("id", calendar.getId());
-	}
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-	@Category({RegressionTests.class})
-	@Test
-	public void testUpdateCalendar() {
-		try {
-			String summaryAfter = getTestRunMessageValue("summaryAfter");
-		
-			Calendar calendar = getTestRunMessageValue("calendar");
-			calendar.setSummary(summaryAfter);
-			upsertOnTestRunMessage("calendarRef", calendar);
-			
-			Calendar afterUpdate = runFlowAndGetPayload("update-calendar");
-			String afterText = afterUpdate.getSummary();
-			assertEquals(afterText, summaryAfter);
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("id");
-			deleteCalendar(calendarId);
-	}
+public class UpdateCalendarTestCases extends GoogleCalendarTestParent {
+
+
+    @Before
+    public void setUp() throws Exception {
+        initializeTestRunMessage("updateCalendar");
+
+        // Insert the calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
+
+        // Update test objects
+        upsertOnTestRunMessage("calendar", calendar);
+        upsertOnTestRunMessage("id", calendar.getId());
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testUpdateCalendar() {
+        try {
+            String summaryAfter = getTestRunMessageValue("summaryAfter");
+
+            Calendar calendar = getTestRunMessageValue("calendar");
+            calendar.setSummary(summaryAfter);
+            upsertOnTestRunMessage("calendarRef", calendar);
+
+            Calendar afterUpdate = runFlowAndGetPayload("update-calendar");
+            String afterText = afterUpdate.getSummary();
+            assertEquals(afterText, summaryAfter);
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("id");
+        deleteCalendar(calendarId);
+    }
 
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateEventTestCases.java
@@ -10,65 +10,62 @@
 
 package org.mule.module.google.calendar.automation.testcases;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mule.api.MuleEvent;
-import org.mule.api.processor.MessageProcessor;
 import org.mule.module.google.calendar.model.Calendar;
 import org.mule.module.google.calendar.model.Event;
 import org.mule.modules.tests.ConnectorTestUtils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class UpdateEventTestCases extends GoogleCalendarTestParent {
 
-	@Before
-	public void setUp() throws Exception {
-		
-			loadTestRunMessage("updateEvent");
-		
-			// Insert the calendar
-			Calendar calendar = runFlowAndGetPayload("create-calendar");
-			
-			// Update test objects
-			upsertOnTestRunMessage("calendar", calendar);
-			upsertOnTestRunMessage("calendarId", calendar.getId());
-		
-			String beforeText = getTestRunMessageValue("summaryBefore");
-			upsertOnTestRunMessage("text", beforeText);
+    @Before
+    public void setUp() throws Exception {
 
-			Event event = runFlowAndGetPayload("quick-add-event");
-			upsertOnTestRunMessage("event", event);
-			upsertOnTestRunMessage("eventId", event.getId());			
+        initializeTestRunMessage("updateEvent");
 
-	}
-	
-	@Category({RegressionTests.class})
-	@Test
-	public void testUpdateEvent() {
-		try {
-			String summaryAfter = getTestRunMessageValue("summaryAfter");
-			Event event = getTestRunMessageValue("event");
-			event.setSummary(summaryAfter);
-			upsertOnTestRunMessage("calendarEventRef", event);
-	
-			Event afterEvent = runFlowAndGetPayload("update-event");
-			String afterText = afterEvent.getSummary();
-			assertEquals(afterText, summaryAfter);
-		} catch (Exception e) {
-			fail(ConnectorTestUtils.getStackTrace(e));
-		}
-	}
-	
-	@After
-	public void tearDown() throws Exception {
-			String calendarId = getTestRunMessageValue("calendarId");
-			deleteCalendar(calendarId);
+        // Insert the calendar
+        Calendar calendar = runFlowAndGetPayload("create-calendar");
 
-	}
-	
+        // Update test objects
+        upsertOnTestRunMessage("calendar", calendar);
+        upsertOnTestRunMessage("calendarId", calendar.getId());
+
+        String beforeText = getTestRunMessageValue("summaryBefore");
+        upsertOnTestRunMessage("text", beforeText);
+
+        Event event = runFlowAndGetPayload("quick-add-event");
+        upsertOnTestRunMessage("event", event);
+        upsertOnTestRunMessage("eventId", event.getId());
+
+    }
+
+    @Category({RegressionTests.class})
+    @Test
+    public void testUpdateEvent() {
+        try {
+            String summaryAfter = getTestRunMessageValue("summaryAfter");
+            Event event = getTestRunMessageValue("event");
+            event.setSummary(summaryAfter);
+            upsertOnTestRunMessage("calendarEventRef", event);
+
+            Event afterEvent = runFlowAndGetPayload("update-event");
+            String afterText = afterEvent.getSummary();
+            assertEquals(afterText, summaryAfter);
+        } catch (Exception e) {
+            fail(ConnectorTestUtils.getStackTrace(e));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        String calendarId = getTestRunMessageValue("calendarId");
+        deleteCalendar(calendarId);
+
+    }
+
 }

--- a/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateEventTestCases.java
+++ b/src/test/java/org/mule/module/google/calendar/automation/testcases/UpdateEventTestCases.java
@@ -28,13 +28,6 @@ public class UpdateEventTestCases extends GoogleCalendarTestParent {
 
         initializeTestRunMessage("updateEvent");
 
-        // Insert the calendar
-        Calendar calendar = runFlowAndGetPayload("create-calendar");
-
-        // Update test objects
-        upsertOnTestRunMessage("calendar", calendar);
-        upsertOnTestRunMessage("calendarId", calendar.getId());
-
         String beforeText = getTestRunMessageValue("summaryBefore");
         upsertOnTestRunMessage("text", beforeText);
 
@@ -63,9 +56,7 @@ public class UpdateEventTestCases extends GoogleCalendarTestParent {
 
     @After
     public void tearDown() throws Exception {
-        String calendarId = getTestRunMessageValue("calendarId");
-        deleteCalendar(calendarId);
-
+        runFlowAndGetPayload("delete-event");
     }
 
 }

--- a/src/test/resources/AutomationSpringBeans.xml
+++ b/src/test/resources/AutomationSpringBeans.xml
@@ -44,21 +44,21 @@
 	</util:map>
 	
 	<util:map id="clearCalendar" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <!-- clear-calendar only works for primary calendars. The ID of a primary calendar is the enail of who owns the calendar (or simply "primary") -->
-		<entry key="id" value="primary" />
-	    <entry key="numEvents" value="#{15}" />
+	    <!-- clear-calendar only works for primary calendars. The ID of a primary calendar is the email of who owns the calendar (or simply "primary") -->
+		<entry key="calendarId" value="primary" />
+	    <entry key="numEvents" value="#{5}" />
 		<entry key="sampleEvent">
 	        <bean class="org.mule.module.google.calendar.model.Event">
 	            <property name="location" value="New York" />
 	        	<property name="summary" value="Business event" />
 	            <property name="start">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2014-02-10" />
+					    <property name="date" value="2015-02-10" />
 					</bean>
 	            </property>
 	            <property name="end">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2014-02-13" />
+					    <property name="date" value="2015-02-13" />
 					</bean>
 	            </property>
 	        </bean>
@@ -66,32 +66,15 @@
 	</util:map>
 	
 	<util:map id="getCalendarById" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-	</util:map>
-	
-	<util:map id="getCalendarList" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="numCalendars" value="#{3}" />
+	    <entry key="calendarId" value="primary" />
 	</util:map>
 	
 	<util:map id="getCalendarListById" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-		<entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-		</entry>
+		<entry key="calendarId" value="primary"/>
 	</util:map>
 	
 	<util:map id="updateCalendarList" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-		<entry key="colorBefore" value="3" />
+	    <entry key="calendarId" value="primary" />
 		<entry key="colorAfter" value="13" />
 	</util:map>
 	
@@ -118,18 +101,14 @@
 	</util:map>
 	
 	<util:map id="insertEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-		</entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="calendarEventRef">
 	      	<bean class="org.mule.module.google.calendar.model.Event" scope="prototype">
 				<property name="location" value="America" />
 				<property name="summary" value="This is a summary about the event" />
 				<property name="start">
 			    	<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2012-12-16" />
+					    <property name="date" value="2015-12-16" />
 					</bean>
 			    </property>
 				<property name="end">
@@ -142,23 +121,19 @@
 	</util:map>
 	
 	<util:map id="importEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-			<bean class="org.mule.module.google.calendar.model.Calendar">
-	            <property name="summary" value="Test calendar to clear" />
-	        </bean>
-	    </entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="event">
 	        <bean class="org.mule.module.google.calendar.model.Event">
 	            <property name="location" value="Buenos Aires" />
 	        	<property name="summary" value="Fake Mulesoft Test Cloud Connectors Meetup " />
 	            <property name="start">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2013-12-16" />
+					    <property name="date" value="2015-12-16" />
 					</bean>
 	            </property>
 	            <property name="end">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2013-12-20" />
+					    <property name="date" value="2015-12-20" />
 					</bean>
 	            </property>
 	        </bean>
@@ -166,18 +141,14 @@
 	</util:map>
 	
 	<util:map id="getEventById" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="calendarEventRef">
 	      	<bean class="org.mule.module.google.calendar.model.Event" scope="prototype">
-				<property name="location" value="America" />
+				<property name="location" value="North America" />
 				<property name="summary" value="This is a summary about the event" />
 				<property name="start">
 			    	<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2012-12-16" />
+					    <property name="date" value="2015-12-16" />
 					</bean>
 			    </property>
 				<property name="end">
@@ -190,23 +161,19 @@
 	</util:map>
 	
 	<util:map id="getInstances" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="calendarEventRef">
 	      	<bean class="org.mule.module.google.calendar.model.Event" scope="prototype">
-				<property name="location" value="America" />
+				<property name="location" value="South America" />
 				<property name="summary" value="This is a summary about the event" />
 				<property name="start">
 			    	<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2012-12-16" />
+					    <property name="date" value="2014-12-16" />
 					</bean>
 			    </property>
 				<property name="end">
 				    <bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-02-20" />
+						<property name="date" value="2015-02-20" />
 					</bean>
 				</property>
 			</bean>
@@ -214,23 +181,19 @@
 	</util:map>
 	
 	<util:map id="deleteEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="calendarEventRef">
 	      	<bean class="org.mule.module.google.calendar.model.Event" scope="prototype">
 				<property name="location" value="America" />
 				<property name="summary" value="This is a summary about the event" />
 				<property name="start">
 			    	<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2012-12-16" />
+					    <property name="date" value="2016-12-16" />
 					</bean>
 			    </property>
 				<property name="end">
 				    <bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-02-20" />
+						<property name="date" value="2017-02-20" />
 					</bean>
 				</property>
 			</bean>
@@ -238,28 +201,20 @@
 	</util:map>
 	
 	<util:map id="quickAddEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="text" value="Sample text for event" />
 	</util:map>
 	
 	<util:map id="batchInsertEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-	    <entry key="numEvents" value="#{5}" />
+	    <entry key="calendarId" value="primary" />
+	    <entry key="numEvents" value="#{3}" />
 	    <entry key="sampleEvent">
 	        <bean class="org.mule.module.google.calendar.model.Event">
-				<property name="location" value="New York" />
+				<property name="location" value="New Jersey" />
 	        	<property name="summary" value="Business trip" />
 	            <property name="start">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2012-12-16" />
+					    <property name="date" value="2014-12-16" />
 					</bean>
 	            </property>
 	            <property name="end">
@@ -272,32 +227,24 @@
 	</util:map>
 	
 	<util:map id="batchUpdateEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-	    <entry key="numEvents" value="#{10}" />
+	    <entry key="calendarId" value="primary" />
+	    <entry key="numEvents" value="#{3}" />
 	    <entry key="summaryBefore" value="Ice skating in Alaska" />
 	    <entry key="summaryAfter" value="Trip to Disneyland" />
 	    <entry key="eventStart">
 			<bean class="org.mule.module.google.calendar.model.EventDateTime">
-				<property name="date" value="2014-02-10" />
+				<property name="date" value="2016-02-10" />
 			</bean>
 	    </entry>
 	    <entry key="eventEnd">
 			<bean class="org.mule.module.google.calendar.model.EventDateTime">
-				<property name="date" value="2014-02-10" />
+				<property name="date" value="2016-02-10" />
 			</bean>
 	    </entry>
 	</util:map>
 	
 	<util:map id="moveEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="sourceCalendarRef">
-	        <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="This is the source calendar" />	    
-    		</bean>
-	    </entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="targetCalendarRef">
 	        <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
 				<property name="summary" value="This is the target calendar" />	    
@@ -309,12 +256,12 @@
 	        	<property name="summary" value="Business trip" />
 	            <property name="start">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2014-02-10" />
+					    <property name="date" value="2016-02-10" />
 					</bean>
 	            </property>
 	            <property name="end">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2014-02-13" />
+					    <property name="date" value="2016-02-13" />
 					</bean>
 	            </property>
 	        </bean>
@@ -322,39 +269,27 @@
 	</util:map>
 	
 	<util:map id="updateEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
+        <!-- The ID of a primary calendar is the email of who owns the calendar (or simply "primary") -->
+	    <entry key="calendarId" value="primary"/>
 		<entry key="summaryBefore" value="This is the title before update" />
 		<entry key="summaryAfter" value="This is the title after update" />
 	</util:map>
 	
 	<util:map id="updateCalendar" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-		<entry key="summaryBefore" value="This is the summary before update" />
+	    <entry key="calendarId" value="primary" />
 		<entry key="summaryAfter" value="This is the summary after update" />
 	</util:map>
 	
 	<util:map id="batchDeleteEvent" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-	    <entry key="numEvents" value="#{5}" />
+	    <entry key="calendarId" value="primary" />
+	    <entry key="numEvents" value="#{3}" />
 	    <entry key="sampleEvent">
 	        <bean class="org.mule.module.google.calendar.model.Event">
 				<property name="location" value="New York" />
 	        	<property name="summary" value="Business trip" />
 	            <property name="start">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2012-12-16" />
+					    <property name="date" value="2014-10-16" />
 					</bean>
 	            </property>
 	            <property name="end">
@@ -367,56 +302,36 @@
 	</util:map>
 	
 	<util:map id="insertAclRule" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-		<entry key="scope" value="karthik.anantha@mulesoft.com"/>
-		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).USER}" />
-		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).writer}" />
+	    <entry key="calendarId" value="primary" />
+		<entry key="scope" value="mulesoft.com"/>
+		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).DOMAIN}" />
+		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).owner}" />
 	</util:map>
 
 	<util:map id="updateAclRule" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-		<entry key="scope" value="karthik.anantha@mulesoft.com"/>
-		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).USER}" />
+	    <entry key="calendarId" value="primary" />
+		<entry key="scope" value="mulesoft.com"/>
+		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).DOMAIN}" />
 		<entry key="roleBefore" value="#{T(org.mule.module.google.calendar.ScopeRole).owner}" />
 		<entry key="roleAfter" value="#{T(org.mule.module.google.calendar.ScopeRole).writer}" />
 	</util:map>
 	
 	<util:map id="getAclRuleById" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-		<entry key="scope" value="karthik.anantha@mulesoft.com"/>
-		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).USER}" />
-		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).writer}" />
+	    <entry key="calendarId" value="primary" />
+		<entry key="scope" value="mulesoft.com" />
+		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).DOMAIN}" />
+		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).owner}" />
 	</util:map>
 		
 	<util:map id="deleteAclRule" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
-		<entry key="scope" value="karthik.anantha@mulesoft.com"/>
-		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).USER}" />
-		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).writer}" />
+	    <entry key="calendarId" value="primary" />
+		<entry key="scope" value="mulesoft.com"/>
+		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).DOMAIN}" />
+		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).owner}" />
 	</util:map>
 
 	<util:map id="getAllAclRules" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="scopes">
 	        <list>
 	            <value>a-mulesoft-email@mulesoft.com</value>
@@ -429,11 +344,11 @@
 	</util:map>
 
 	<util:map id="getEvents" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
+        <entry key="calendarRef">
+            <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
+                <property name="summary" value="Sample title for calendar" />
+            </bean>
+        </entry>
 	    <entry key="numEvents" value="#{20}" />
 	    <entry key="maxResults" value="#{10}" />
 	    <entry key="showDeleted" value="false" />
@@ -443,7 +358,7 @@
 	        	<property name="summary" value="Hosting an event at a location" />
 	            <property name="start">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2012-12-16" />
+					    <property name="date" value="2014-12-16" />
 					</bean>
 	            </property>
 	            <property name="end">
@@ -456,11 +371,7 @@
 	</util:map>
 	
 	<util:map id="getFreeTime" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
-	    <entry key="calendarRef">
-		    <bean class="org.mule.module.google.calendar.model.Calendar" scope="prototype">
-				<property name="summary" value="Sample title for calendar" />	    
-	    	</bean>
-	    </entry>
+	    <entry key="calendarId" value="primary" />
 	    <entry key="event">
 	        <bean class="org.mule.module.google.calendar.model.Event">
 	            <property name="location" value="Ontario" />
@@ -469,7 +380,7 @@
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
 					    <property name="dateTime">
 							<bean class="org.mule.modules.google.api.datetime.DateTime">
-								<constructor-arg value="#{T(com.google.api.client.util.DateTime).parseRfc3339('2013-12-16T00:00:00Z')}" />								
+								<constructor-arg value="#{T(com.google.api.client.util.DateTime).parseRfc3339('2013-12-16T00:00:00Z')}" />
 							</bean>
 						</property>
 					</bean>

--- a/src/test/resources/AutomationSpringBeans.xml
+++ b/src/test/resources/AutomationSpringBeans.xml
@@ -53,12 +53,12 @@
 	        	<property name="summary" value="Business event" />
 	            <property name="start">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2014-2-10" />
+					    <property name="date" value="2014-02-10" />
 					</bean>
 	            </property>
 	            <property name="end">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2014-2-13" />
+					    <property name="date" value="2014-02-13" />
 					</bean>
 	            </property>
 	        </bean>
@@ -134,7 +134,7 @@
 			    </property>
 				<property name="end">
 				    <bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-2-20" />
+						<property name="date" value="2016-02-20" />
 					</bean>
 				</property>
 			</bean>
@@ -182,7 +182,7 @@
 			    </property>
 				<property name="end">
 				    <bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-2-20" />
+						<property name="date" value="2016-02-20" />
 					</bean>
 				</property>
 			</bean>
@@ -206,7 +206,7 @@
 			    </property>
 				<property name="end">
 				    <bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-2-20" />
+						<property name="date" value="2016-02-20" />
 					</bean>
 				</property>
 			</bean>
@@ -230,7 +230,7 @@
 			    </property>
 				<property name="end">
 				    <bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-2-20" />
+						<property name="date" value="2016-02-20" />
 					</bean>
 				</property>
 			</bean>
@@ -264,7 +264,7 @@
 	            </property>
 	            <property name="end">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-2-20" />
+						<property name="date" value="2016-02-20" />
 					</bean>
 	            </property>
 	        </bean>
@@ -282,12 +282,12 @@
 	    <entry key="summaryAfter" value="Trip to Disneyland" />
 	    <entry key="eventStart">
 			<bean class="org.mule.module.google.calendar.model.EventDateTime">
-				<property name="date" value="2014-2-10" />
+				<property name="date" value="2014-02-10" />
 			</bean>
 	    </entry>
 	    <entry key="eventEnd">
 			<bean class="org.mule.module.google.calendar.model.EventDateTime">
-				<property name="date" value="2014-2-10" />
+				<property name="date" value="2014-02-10" />
 			</bean>
 	    </entry>
 	</util:map>
@@ -309,12 +309,12 @@
 	        	<property name="summary" value="Business trip" />
 	            <property name="start">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2014-2-10" />
+					    <property name="date" value="2014-02-10" />
 					</bean>
 	            </property>
 	            <property name="end">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-					    <property name="date" value="2014-2-13" />
+					    <property name="date" value="2014-02-13" />
 					</bean>
 	            </property>
 	        </bean>
@@ -359,7 +359,7 @@
 	            </property>
 	            <property name="end">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-2-20" />
+						<property name="date" value="2016-02-20" />
 					</bean>
 	            </property>
 	        </bean>
@@ -372,9 +372,9 @@
 				<property name="summary" value="Sample title for calendar" />	    
 	    	</bean>
 	    </entry>
-		<entry key="scope" value="mulesoft.com"/>
-		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).DOMAIN}" />
-		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).owner}" />
+		<entry key="scope" value="karthik.anantha@mulesoft.com"/>
+		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).USER}" />
+		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).writer}" />
 	</util:map>
 
 	<util:map id="updateAclRule" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
@@ -383,8 +383,8 @@
 				<property name="summary" value="Sample title for calendar" />	    
 	    	</bean>
 	    </entry>
-		<entry key="scope" value="mulesoft.com"/>
-		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).DOMAIN}" />
+		<entry key="scope" value="karthik.anantha@mulesoft.com"/>
+		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).USER}" />
 		<entry key="roleBefore" value="#{T(org.mule.module.google.calendar.ScopeRole).owner}" />
 		<entry key="roleAfter" value="#{T(org.mule.module.google.calendar.ScopeRole).writer}" />
 	</util:map>
@@ -395,9 +395,9 @@
 				<property name="summary" value="Sample title for calendar" />	    
 	    	</bean>
 	    </entry>
-		<entry key="scope" value="mulesoft.com"/>
-		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).DOMAIN}" />
-		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).owner}" />
+		<entry key="scope" value="karthik.anantha@mulesoft.com"/>
+		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).USER}" />
+		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).writer}" />
 	</util:map>
 		
 	<util:map id="deleteAclRule" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
@@ -406,9 +406,9 @@
 				<property name="summary" value="Sample title for calendar" />	    
 	    	</bean>
 	    </entry>
-		<entry key="scope" value="mulesoft.com"/>
-		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).DOMAIN}" />
-		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).owner}" />
+		<entry key="scope" value="karthik.anantha@mulesoft.com"/>
+		<entry key="scopeType" value="#{T(org.mule.module.google.calendar.ScopeType).USER}" />
+		<entry key="role" value="#{T(org.mule.module.google.calendar.ScopeRole).writer}" />
 	</util:map>
 
 	<util:map id="getAllAclRules" key-type="java.lang.String" value-type="java.lang.Object" scope="prototype">
@@ -448,7 +448,7 @@
 	            </property>
 	            <property name="end">
 					<bean class="org.mule.module.google.calendar.model.EventDateTime">
-						<property name="date" value="2016-2-20" />
+						<property name="date" value="2016-02-20" />
 					</bean>
 	            </property>
 	        </bean>

--- a/src/test/resources/automation-test-flows.xml
+++ b/src/test/resources/automation-test-flows.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-	xmlns:spring="http://www.springframework.org/schema/beans" version="EE-3.4.0"
+	xmlns:spring="http://www.springframework.org/schema/beans" version="EE-3.5.0"
 	xmlns:http="http://www.mulesoft.org/schema/mule/http"
 	xmlns:google-calendars="http://www.mulesoft.org/schema/mule/google-calendars"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"

--- a/src/test/resources/automation-test-flows.xml
+++ b/src/test/resources/automation-test-flows.xml
@@ -23,15 +23,15 @@ http://www.mulesoft.org/schema/mule/google-calendars http://www.mulesoft.org/sch
 	</flow>
 	
 	<flow name="delete-calendar" doc:name="delete-calendar">
-	    <google-calendars:delete-calendar id="#[payload.id]" accessTokenId="accessTokenId" config-ref="Google_Calendars"/>
+	    <google-calendars:delete-calendar id="#[payload.calendarId]" accessTokenId="accessTokenId" config-ref="Google_Calendars"/>
 	</flow>
 	
 	<flow name="clear-calendar" doc:name="clear-calendar">
-	    <google-calendars:clear-calendar config-ref="Google_Calendars" id="#[payload.id]" accessTokenId="accessTokenId" />
+	    <google-calendars:clear-calendar config-ref="Google_Calendars" id="#[payload.calendarId]" accessTokenId="accessTokenId" />
 	</flow>
 	
 	<flow name="get-calendar-by-id" doc:name="get-calendar-by-id">
-	    <google-calendars:get-calendar-by-id id="#[payload.id]" accessTokenId="accessTokenId" config-ref="Google_Calendars" />
+	    <google-calendars:get-calendar-by-id id="#[payload.calendarId]" accessTokenId="accessTokenId" config-ref="Google_Calendars" />
 	</flow>
 	
 	<flow name="get-calendar-list" doc:name="get-calendar-list">
@@ -39,15 +39,15 @@ http://www.mulesoft.org/schema/mule/google-calendars http://www.mulesoft.org/sch
 	</flow>
 	
 	<flow name="get-calendar-list-by-id" doc:name="get-calendar-list-by-id">
-		<google-calendars:get-calendar-list-by-id config-ref="Google_Calendars" id="#[payload.id]" accessTokenId="accessTokenId" />
+		<google-calendars:get-calendar-list-by-id config-ref="Google_Calendars" id="#[payload.calendarId]" accessTokenId="accessTokenId" />
 	</flow>
 	
 	<flow name="update-calendar-list" doc:name="update-calendar-list">
-		<google-calendars:update-calendar-list config-ref="Google_Calendars" calendarList-ref="#[payload.calendarListRef]"  id="#[payload.id]" accessTokenId="accessTokenId" />
+		<google-calendars:update-calendar-list config-ref="Google_Calendars" calendarList-ref="#[payload.calendarListRef]"  id="#[payload.calendarId]" accessTokenId="accessTokenId" />
 	</flow>
 	
 	<flow name="delete-calendar-list" doc:name="delete-calendar-list">
-		<google-calendars:delete-calendar-list config-ref="Google_Calendars" id="#[payload.id]" accessTokenId="accessTokenId"/>
+		<google-calendars:delete-calendar-list config-ref="Google_Calendars" id="#[payload.calendarId]" accessTokenId="accessTokenId"/>
 	</flow>
 	
 	<flow name="batch-insert-calendar" doc:name="batch-insert-calendar">
@@ -83,7 +83,7 @@ http://www.mulesoft.org/schema/mule/google-calendars http://www.mulesoft.org/sch
 	</flow>
 	
 	<flow name="move-event" doc:name="move-event">
-	    <google-calendars:move-event config-ref="Google_Calendars" eventId="#[payload.eventId]" sourceCalendarId="#[payload.sourceCalendarId]" targetCalendarId="#[payload.targetCalendarId]" accessTokenId="accessTokenId"  />
+	    <google-calendars:move-event config-ref="Google_Calendars" eventId="#[payload.eventId]" sourceCalendarId="#[payload.calendarId]" targetCalendarId="#[payload.targetCalendarId]" accessTokenId="accessTokenId"  />
 	</flow>
 	
 	<flow name="update-event" doc:name="update-event">
@@ -103,7 +103,7 @@ http://www.mulesoft.org/schema/mule/google-calendars http://www.mulesoft.org/sch
 	</flow>
 	
 	<flow name="update-calendar" doc:name="update-calendar">
-		<google-calendars:update-calendar config-ref="Google_Calendars" id="#[payload.id]" calendar-ref="#[payload.calendarRef]" accessTokenId="accessTokenId" />	
+		<google-calendars:update-calendar config-ref="Google_Calendars" id="#[payload.calendarId]" calendar-ref="#[payload.calendarRef]" accessTokenId="accessTokenId" />
 	</flow>
 
 	<flow name="get-free-time" doc:name="get-free-time">


### PR DESCRIPTION
- Upgraded google api services calendar to v3-rev77-1.17.0-rc.
- Upgraded Devkit to 3.5.0-SNAPSHOT.
- Fixed Class Versioning Issue.
- Fixed Quick add events operation hung issue.
- Removed @Optional as it is redundant when used along @Default.
- Removed deprecated @OAuthInvalidateAccessTokenOn and added @ReconnectOn on the Connector.
- Fixed test cases
  - If a test is not functionally designed to test calendar creation or deletion, it just uses the default/primary calendar.
  - If a test is working on an event, it uses different test data to any other test that uses an event.
  - Added sleep time (10 sec) between each operation to slow down the hits to the google api.
- Known Issues
  - Avoid executing Regression/Smoke test suites multiple times in a single day in order to avoid "Calendar usage limits exceeded." error.
